### PR TITLE
Refactor global variables to static with accessors

### DIFF
--- a/include/error_management.h
+++ b/include/error_management.h
@@ -12,6 +12,9 @@
 #ifndef ERROR_MANAGEMENT_H
 #define ERROR_MANAGEMENT_H
 
+#include <stdint.h>
+#include <stdbool.h>
+
 // Error LED configuration
 #define ERROR_LED_PIN PICO_DEFAULT_LED_PIN
 
@@ -70,9 +73,59 @@ typedef struct statistics_counters_t {
 } statistics_counters_t;
 
 /**
- * @brief Holds various statistics counters for error tracking.
+ * @brief Increment a statistics counter.
+ *
+ * @param[in] index Counter index to increment.
  */
-extern volatile statistics_counters_t statistics_counters;
+void statistics_increment_counter(statistics_counter_enum_t index);
+
+/**
+ * @brief Add a value to a statistics counter.
+ *
+ * @param[in] index Counter index to update.
+ * @param[in] value Value to add.
+ */
+void statistics_add_to_counter(statistics_counter_enum_t index, uint32_t value);
+
+/**
+ * @brief Set a statistics counter to a specific value.
+ *
+ * @param[in] index Counter index to set.
+ * @param[in] value Value to assign.
+ */
+void statistics_set_counter(statistics_counter_enum_t index, uint32_t value);
+
+/**
+ * @brief Retrieve the value of a statistics counter.
+ *
+ * @param[in] index Counter index to read.
+ * @return Current counter value.
+ */
+uint32_t statistics_get_counter(statistics_counter_enum_t index);
+
+/**
+ * @brief Reset all statistics counters.
+ */
+void statistics_reset_all_counters(void);
+
+/**
+ * @brief Check if the system is in an error state.
+ *
+ * @return true if in error state, false otherwise.
+ */
+bool statistics_is_error_state(void);
+
+/**
+ * @brief Get the current error type.
+ *
+ * @return Current error type.
+ */
+error_type_t statistics_get_error_type(void);
+
+/**
+ * @brief Clear the error state and set error type to ERROR_NONE.
+ */
+void statistics_clear_error(void);
 
 /**
  * @brief Set the error state persistently in the watchdog registers.

--- a/include/hooks.h
+++ b/include/hooks.h
@@ -6,7 +6,6 @@
 #include "task.h"
 #include "semphr.h"
 
-extern volatile size_t free_heap_size;
 
 /* Prototypes for the standard FreeRTOS callback/hook functions implemented
  * within this file. */

--- a/include/inputs.h
+++ b/include/inputs.h
@@ -125,10 +125,6 @@ typedef struct input_config_t
 	uint16_t encoder_settling_time_ms; /**< Encoder settling time in milliseconds */
 } input_config_t;
 
-/**
- * @brief Global input configuration instance.
- */
-extern input_config_t input_config;
 
 /**
  * @brief Possible results for input functions.
@@ -160,12 +156,6 @@ typedef struct encoder_states_t
 	int8_t count_encoder; /**< Encoder step counter */
 } encoder_states_t;
 
-/**
- * @brief Current state of each key in the keypad matrix.
- *
- * The size is KEYPAD_MAX_COLS * KEYPAD_MAX_ROWS.
- */
-extern uint8_t keypad_state[KEYPAD_MAX_COLS * KEYPAD_MAX_ROWS];
 
 /**
  * @brief Initialize the input system (keypad, ADC, encoder).

--- a/include/outputs.h
+++ b/include/outputs.h
@@ -146,7 +146,6 @@ typedef struct out_statistics_counters_t {
 	bool error_state;                  /**< Flag indicating critical error state */
 } out_statistics_counters_t;
 
-extern out_statistics_counters_t out_statistics_counters;
 
 // --- Driver Structures ---
 
@@ -185,7 +184,6 @@ typedef struct output_drivers_t {
 	output_driver_t *driver_handles[MAX_SPI_INTERFACES];
 } output_drivers_t;
 
-extern output_drivers_t output_drivers;
 
 /**
  * Function Prototypes

--- a/src/error_management.c
+++ b/src/error_management.c
@@ -20,12 +20,58 @@
 #include "task.h"
 #include "error_management.h"
 
-// Global variable
-volatile statistics_counters_t statistics_counters = {
-	.counters = {0},
-	.error_state = false,
-	.current_error_type = ERROR_NONE
+/**
+ * @brief Statistics counters instance (module scope).
+ */
+static volatile statistics_counters_t statistics_counters = {
+        .counters = {0},
+        .error_state = false,
+        .current_error_type = ERROR_NONE
 };
+
+void statistics_increment_counter(statistics_counter_enum_t index)
+{
+        statistics_counters.counters[index]++;
+}
+
+void statistics_add_to_counter(statistics_counter_enum_t index, uint32_t value)
+{
+        statistics_counters.counters[index] += value;
+}
+
+void statistics_set_counter(statistics_counter_enum_t index, uint32_t value)
+{
+        statistics_counters.counters[index] = value;
+}
+
+uint32_t statistics_get_counter(statistics_counter_enum_t index)
+{
+        return statistics_counters.counters[index];
+}
+
+void statistics_reset_all_counters(void)
+{
+        for (uint32_t i = 0; i < NUM_STATISTICS_COUNTERS; i++)
+        {
+                statistics_counters.counters[i] = 0;
+        }
+}
+
+bool statistics_is_error_state(void)
+{
+        return statistics_counters.error_state;
+}
+
+error_type_t statistics_get_error_type(void)
+{
+        return statistics_counters.current_error_type;
+}
+
+void statistics_clear_error(void)
+{
+        statistics_counters.error_state = false;
+        statistics_counters.current_error_type = ERROR_NONE;
+}
 
 void show_error_pattern_blocking(error_type_t error_type)
 {

--- a/src/hooks.c
+++ b/src/hooks.c
@@ -12,7 +12,7 @@
 #include "hooks.h"
 #include "error_management.h"
 
-volatile size_t free_heap_size = 0;
+static volatile size_t free_heap_size = 0;
 
 //-----------------------------------------------------------
 

--- a/src/inputs.c
+++ b/src/inputs.c
@@ -20,14 +20,14 @@
 #include "error_management.h"
 
 /**
- * @brief Global input configuration instance.
+ * @brief Input configuration instance (module scope).
  */
-input_config_t input_config;
+static input_config_t input_config;
 
 /**
  * @brief State array for each key in the keypad matrix.
  */
-uint8_t keypad_state[KEYPAD_ROWS * KEYPAD_COLUMNS];
+static uint8_t keypad_state[KEYPAD_ROWS * KEYPAD_COLUMNS];
 
 /**
  * @brief ADC states for each channel.

--- a/src/main.c
+++ b/src/main.c
@@ -375,14 +375,14 @@ static void uart_event_task(void *pvParameters)
 			continue;
 		}
 
-		uint32_t count = tud_cdc_n_read(0, receive_buffer, sizeof(receive_buffer));
-		statistics_counters.counters[BYTES_RECEIVED] += count;
+                uint32_t count = tud_cdc_n_read(0, receive_buffer, sizeof(receive_buffer));
+                statistics_add_to_counter(BYTES_RECEIVED, count);
 		for (uint32_t i = 0; (i < count) && (i < MAX_ENCODED_BUFFER_SIZE); i++)
 		{
-			if (xQueueSend(encoded_reception_queue, &receive_buffer[i], pdMS_TO_TICKS(5)) != pdTRUE)
-			{
-				statistics_counters.counters[QUEUE_SEND_ERROR]++;
-			}
+                        if (xQueueSend(encoded_reception_queue, &receive_buffer[i], pdMS_TO_TICKS(5)) != pdTRUE)
+                        {
+                                statistics_increment_counter(QUEUE_SEND_ERROR);
+                        }
 			update_watchdog_safe();
 		}
 	}
@@ -412,14 +412,14 @@ static void send_data(uint16_t id, uint8_t command, const uint8_t *send_data, ui
 	// Check for NULL pointer
 	if (NULL == send_data)
 	{
-		statistics_counters.counters[QUEUE_SEND_ERROR]++;
+            statistics_increment_counter(QUEUE_SEND_ERROR);
 		error = true;
 	}
 
 	// Check for buffer overflow risk
 	if ((false == error) && (length > (DATA_BUFFER_SIZE - HEADER_SIZE - CHECKSUM_SIZE)))
 	{
-		statistics_counters.counters[BUFFER_OVERFLOW_ERROR]++;
+            statistics_increment_counter(BUFFER_OVERFLOW_ERROR);
 		error = true;
 	}
 
@@ -444,7 +444,7 @@ static void send_data(uint16_t id, uint8_t command, const uint8_t *send_data, ui
 		// Check for buffer overflow after encoding
 		if ((num_encoded + 1U) >= MAX_ENCODED_BUFFER_SIZE)
 		{
-			statistics_counters.counters[BUFFER_OVERFLOW_ERROR]++;
+                    statistics_increment_counter(BUFFER_OVERFLOW_ERROR);
 		}
 		else
 		{
@@ -458,7 +458,7 @@ static void send_data(uint16_t id, uint8_t command, const uint8_t *send_data, ui
 			// Enqueue data to be sent via USB CDC
 			if (xQueueSend(cdc_transmit_queue, &packet, pdMS_TO_TICKS(1)) != pdTRUE)
 			{
-				statistics_counters.counters[CDC_QUEUE_SEND_ERROR]++;
+                            statistics_increment_counter(CDC_QUEUE_SEND_ERROR);
 			}
 		}
 	}
@@ -497,7 +497,7 @@ static void cdc_write_task(void *pvParameters)
 				taskYIELD();
 			}
 			// Flush after all possible bytes are written
-			statistics_counters.counters[BYTES_SENT] += total_written;
+                    statistics_add_to_counter(BYTES_SENT, total_written);
 			tud_cdc_write_flush();
 		}
 		task_prop->high_watermark = uxTaskGetStackHighWaterMark(NULL);
@@ -513,10 +513,11 @@ static inline void send_status(uint8_t index)
 	if (index < (uint8_t)NUM_STATISTICS_COUNTERS)
 	{
 		data[0] = index;
-		data[1] = (statistics_counters.counters[index] >> 24U) & 0xFFU;
-		data[2] = (statistics_counters.counters[index] >> 16U) & 0xFFU;
-		data[3] = (statistics_counters.counters[index] >> 8U) & 0xFFU;
-		data[4] = statistics_counters.counters[index] & 0xFFU;
+            uint32_t counter_value = statistics_get_counter(index);
+            data[1] = (counter_value >> 24U) & 0xFFU;
+            data[2] = (counter_value >> 16U) & 0xFFU;
+            data[3] = (counter_value >> 8U) & 0xFFU;
+            data[4] = counter_value & 0xFFU;
 	}
 
 	send_data(BOARD_ID, PC_ERROR_STATUS_CMD, data, sizeof(data));
@@ -603,7 +604,7 @@ static void process_inbound_data(const uint8_t *rx_buffer, size_t length)
 
 	if (length < (HEADER_SIZE + CHECKSUM_SIZE))
 	{
-		statistics_counters.counters[MSG_MALFORMED_ERROR]++;
+            statistics_increment_counter(MSG_MALFORMED_ERROR);
 		done = true;
 	}
 
@@ -620,20 +621,20 @@ static void process_inbound_data(const uint8_t *rx_buffer, size_t length)
 
 		if (length != (len + HEADER_SIZE + CHECKSUM_SIZE))
 		{
-			statistics_counters.counters[MSG_MALFORMED_ERROR]++;
+                    statistics_increment_counter(MSG_MALFORMED_ERROR);
 			done = true;
 		}
 	}
 
 	if ((!done) && (DATA_BUFFER_SIZE < len))
 	{
-		statistics_counters.counters[BUFFER_OVERFLOW_ERROR]++;
+            statistics_increment_counter(BUFFER_OVERFLOW_ERROR);
 		done = true;
 	}
 
 	if ((!done) && (rxID != BOARD_ID))
 	{
-		statistics_counters.counters[UNKNOWN_CMD_ERROR]++;
+            statistics_increment_counter(UNKNOWN_CMD_ERROR);
 		done = true;
 	}
 
@@ -646,7 +647,7 @@ static void process_inbound_data(const uint8_t *rx_buffer, size_t length)
 
 		if (calculated_checksum != received_checksum)
 		{
-			statistics_counters.counters[CHECKSUM_ERROR]++;
+                    statistics_increment_counter(CHECKSUM_ERROR);
 			done = true;
 		}
 	}
@@ -658,7 +659,7 @@ static void process_inbound_data(const uint8_t *rx_buffer, size_t length)
 		case PC_LEDOUT_CMD:
 			if (led_out(decoded_data, len) != OUTPUT_OK)
 			{
-				statistics_counters.counters[LED_OUT_ERROR]++;
+                            statistics_increment_counter(LED_OUT_ERROR);
 			}
 			break;
 
@@ -669,7 +670,7 @@ static void process_inbound_data(const uint8_t *rx_buffer, size_t length)
 		case PC_DPYCTL_CMD:
 			if (display_out(decoded_data, len) != OUTPUT_OK)
 			{
-				statistics_counters.counters[DISPLAY_OUT_ERROR]++;
+                            statistics_increment_counter(DISPLAY_OUT_ERROR);
 			}
 			break;
 
@@ -686,7 +687,7 @@ static void process_inbound_data(const uint8_t *rx_buffer, size_t length)
 			break;
 
 		default:
-			statistics_counters.counters[UNKNOWN_CMD_ERROR]++;
+                    statistics_increment_counter(UNKNOWN_CMD_ERROR);
 			break;
 		}
 	}
@@ -708,7 +709,7 @@ static void decode_reception_task(void *pvParameters)
 		uint8_t data;
 		if (pdFALSE == xQueueReceive(encoded_reception_queue, (void *)&data, portMAX_DELAY))
 		{
-			statistics_counters.counters[QUEUE_RECEIVE_ERROR]++;
+                    statistics_increment_counter(QUEUE_RECEIVE_ERROR);
 			continue;
 		}
 
@@ -717,7 +718,7 @@ static void decode_reception_task(void *pvParameters)
 			if (0U == receive_buffer_index)
 			{
 				// Packet marker received but no data in buffer
-				statistics_counters.counters[COBS_DECODE_ERROR]++;
+                            statistics_increment_counter(COBS_DECODE_ERROR);
 				receive_buffer_index = 0;
 				continue;
 			}
@@ -733,7 +734,7 @@ static void decode_reception_task(void *pvParameters)
 			}
 			else
 			{
-				statistics_counters.counters[COBS_DECODE_ERROR]++;
+                            statistics_increment_counter(COBS_DECODE_ERROR);
 			}
 		}
 		else if (receive_buffer_index < MAX_ENCODED_BUFFER_SIZE - 1U)
@@ -743,7 +744,7 @@ static void decode_reception_task(void *pvParameters)
 		}
 		else
 		{
-			statistics_counters.counters[RECEIVE_BUFFER_OVERFLOW_ERROR]++;
+                    statistics_increment_counter(RECEIVE_BUFFER_OVERFLOW_ERROR);
 			receive_buffer_index = 0;
 		}
 	}
@@ -768,7 +769,7 @@ static void process_outbound_task(void *pvParameters)
 		}
 		else
 		{
-			statistics_counters.counters[QUEUE_RECEIVE_ERROR]++;
+                    statistics_increment_counter(QUEUE_RECEIVE_ERROR);
 		}
 
 		task_prop->high_watermark = uxTaskGetStackHighWaterMark(NULL);
@@ -782,10 +783,10 @@ static void led_status_task(void *pvParameters)
 
 	for (;;)
 	{
-		if (true == statistics_counters.error_state)
+            if (true == statistics_is_error_state())
 		{
 			// Error state - show error pattern
-			uint8_t blink_count = (uint8_t)statistics_counters.current_error_type;
+                    uint8_t blink_count = (uint8_t)statistics_get_error_type();
 
 			// Show blink pattern using FreeRTOS delays
 			for (uint8_t i = 0; i < blink_count; i++) {
@@ -866,10 +867,7 @@ static inline bool setup_hardware(void)
 	}
 
 	// Reset all error counters
-	for (uint i = 0; i < NUM_STATISTICS_COUNTERS; i++)
-	{
-		statistics_counters.counters[i] = 0;
-	}
+        statistics_reset_all_counters();
 
 	// Reset task props
 	for (uint i = 0; i < NUM_TASKS; i++)
@@ -1095,30 +1093,29 @@ int main(void)
 	setup_watchdog_with_error_detection(5000);
 
 	// Handle previous errors
-	if (true == statistics_counters.error_state)
+   if (true == statistics_is_error_state())
 	{
 		// Show error pattern for a limited time using busy_wait
 		for (int i = 0; i < 8; i++) {
-			show_error_pattern_blocking(statistics_counters.current_error_type);
+                   show_error_pattern_blocking(statistics_get_error_type());
 			update_watchdog_safe();
 		}
 
 		// Check error count - if too many, stay in error state
 		uint32_t error_count = watchdog_hw->scratch[WATCHDOG_ERROR_COUNT_REG];
-		statistics_counters.counters[WATCHDOG_ERROR] = error_count;
+           statistics_set_counter(WATCHDOG_ERROR, error_count);
 		if (error_count > 5)
 		{
 			// Too many errors - stay in error state and reset
 			while (true) {
-				show_error_pattern_blocking(statistics_counters.current_error_type);
+                           show_error_pattern_blocking(statistics_get_error_type());
 				update_watchdog_safe();
 			}
 		}
 
 		// Try to recover - clear error state
 		clean_up();
-		statistics_counters.error_state = false;
-		statistics_counters.current_error_type = ERROR_NONE;
+           statistics_clear_error();
 	}
 
 	// Initialize TinyUSB hardware/board

--- a/src/outputs.c
+++ b/src/outputs.c
@@ -40,18 +40,18 @@ static const uint8_t device_config_map[MAX_SPI_INTERFACES] = DEVICE_CONFIG;
 static SemaphoreHandle_t spi_mutex = NULL;
 
 /**
- * @brief Structure holding all output driver handles.
+ * @brief Structure holding all output driver handles (module scope).
  *
- * This global variable stores pointers to the initialized output drivers for each interface.
+ * This variable stores pointers to the initialized output drivers for each interface.
  */
-output_drivers_t output_drivers;
+static output_drivers_t output_drivers;
 
 /**
- * @brief Output statistics counters.
+ * @brief Output statistics counters (module scope).
  *
- * This global variable holds counters for various output-related errors and states.
+ * This variable holds counters for various output-related errors and states.
  */
-out_statistics_counters_t out_statistics_counters;
+static out_statistics_counters_t out_statistics_counters;
 
 // Function declarations
 


### PR DESCRIPTION
## Summary
- limit scope of module data by making former globals static
- expose explicit statistics accessors and update main to use them
- remove unused cross-module variables for inputs, outputs, and hooks

## Testing
- `cmake -S . -B build` *(fails: lib/pico-sdk/pico_sdk_init.cmake missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c918f3c4832f887f870914077c4b