### PR TITLE
Improve USB task latency

### DIFF
--- a/include/FreeRTOSConfig.h
+++ b/include/FreeRTOSConfig.h
@@ -48,7 +48,7 @@
 #define configUSE_TICKLESS_IDLE                 1
 #define configUSE_IDLE_HOOK                     1
 #define configUSE_TICK_HOOK                     1
-#define configTICK_RATE_HZ                      ( ( TickType_t ) 1000 )
+#define configTICK_RATE_HZ                      ( ( TickType_t ) 2000 )
 #define configMAX_PRIORITIES                    10
 #define configMINIMAL_STACK_SIZE                ( configSTACK_DEPTH_TYPE ) 256
 #define configUSE_16_BIT_TICKS                  0

--- a/src/main.c
+++ b/src/main.c
@@ -403,8 +403,8 @@ static void cdc_task(void *pvParameters)
 		// Update high watermark and safely reset watchdog timer
 		task_prop->high_watermark = uxTaskGetStackHighWaterMark(NULL);
 		update_watchdog_safe();
-		vTaskDelay(pdMS_TO_TICKS(2));
-	}
+                taskYIELD();
+        }
 }
 
 static void send_data(uint16_t id, uint8_t command, const uint8_t *send_data, uint8_t length)


### PR DESCRIPTION
## Summary
- Increase FreeRTOS tick rate to 2 kHz for finer scheduling
- Replace CDC task delay with taskYIELD to service TinyUSB more often

## Testing
- `cppcheck --enable=all --std=c11 src/main.c include/FreeRTOSConfig.h`
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68a72fc84f0c832f8defab3380835c82