### PR TITLE
docs: update readme with current tooling and structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,22 @@ Related repos:
 
 - [Signalbridge breakout board](https://github.com/carlosmazzei/signalbridge-board)
 - [Signalbridge test suite](https://github.com/carlosmazzei/signalbridge-test-suite)
-- [Signalbridge firmware](https://github.com/carlosmazzei/signalbridge-controller) (This repo)
+
+## 📂 Repository Structure
+
+- **`src/`** – application source code
+- **`include/`** – public headers
+- **`lib/`** – external libraries (Pico SDK, FreeRTOS-Kernel)
+- **`scripts/`** – helper utilities (`analyze_memory.sh`, `memory_analysis.sh`, `check_placement.py`)
+- **`docs/`** – Doxygen configuration and generated documentation
+- **`assets/`** – logos and images
+- **`.devcontainer/`** – development container configuration
+
+### 🧰 Helper Scripts
+
+- `scripts/analyze_memory.sh` – inspect placement of a variable within an ELF file
+- `scripts/memory_analysis.sh` – generate a detailed memory-usage report after building
+- `scripts/check_placement.py` – Python tool to detect problematic variable locations
 
 ## 🚀 Quick Start
 
@@ -43,17 +58,17 @@ code .
 ```
 
 **What You Get Automatically:**
-- ✅ **ARM Toolchain** (gcc-arm-none-eabi 15:12.2.rel1-1)
-- ✅ **Build System** (CMake 3.25.1, Make)
-- ✅ **Debugging Tools** (GDB multiarch)
-- ✅ **Code Analysis** (Cppcheck 2.10, Uncrustify, SonarLint)
-- ✅ **Documentation** (Doxygen 1.9.4)
+- ✅ **ARM Toolchain** (gcc-arm-none-eabi)
+- ✅ **Build System** (CMake, Make)
+- ✅ **Debugging Tools** (GDB multiarch, OpenOCD)
+- ✅ **Code Analysis** (Cppcheck, Uncrustify, SonarLint, Flawfinder)
+- ✅ **Documentation** (Doxygen)
 - ✅ **VS Code Extensions** (C/C++ tools, CMake, Python, Copilot, Hex Editor)
 - ✅ **Pico SDK & FreeRTOS** (automatically configured)
 - ✅ **Environment Variables** (PICO_SDK_PATH, FREERTOS_KERNEL_PATH)
 
 **DevContainer Configuration Details:**
-- **Base Image**: Debian 12 (Bookworm) stable
+- **Base Image**: Debian (Trixie)
 - **Dependencies**: Managed via `dependencies.json` with version pinning
 - **Post-Setup**: Automated submodule initialization and environment configuration
 - **Extensions**: 11 pre-installed VS Code extensions for embedded development
@@ -69,13 +84,13 @@ code .
 sudo apt update
 sudo apt install -y cmake doxygen python3 build-essential \
     gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib \
-    cppcheck uncrustify git nodejs openjdk-17-jre-headless
+    cppcheck uncrustify git nodejs openjdk-jre-headless
 ```
 
 #### For macOS (using Homebrew)
 ```bash
 brew update
-brew install cmake doxygen python3 arm-none-eabi-gcc cppcheck uncrustify git node openjdk@17
+brew install cmake doxygen python3 arm-none-eabi-gcc cppcheck uncrustify git node openjdk
 ```
 
 #### For Windows
@@ -84,6 +99,7 @@ brew install cmake doxygen python3 arm-none-eabi-gcc cppcheck uncrustify git nod
 3. Install [Doxygen](https://www.doxygen.nl/download.html)
 4. Install [Git for Windows](https://git-scm.com/)
 5. Install [Make for Windows](http://gnuwin32.sourceforge.net/packages/make.htm)
+6. Install [OpenJDK](https://adoptium.net/)
 
 </details>
 
@@ -95,12 +111,12 @@ brew install cmake doxygen python3 arm-none-eabi-gcc cppcheck uncrustify git nod
 The development container provides a complete embedded development environment:
 
 **Build Dependencies** (from `dependencies.json`):
-- **Compiler**: gcc-arm-none-eabi (15:12.2.rel1-1)
-- **Build Tools**: cmake (3.25.1-1), build-essential (12.9)
-- **Debugging**: gdb-multiarch (13.1-3)
-- **Code Quality**: cppcheck (2.10-2), uncrustify, flawfinder (2.0.19-1.1)
-- **Documentation**: doxygen (1.9.4-4)
-- **Runtime**: nodejs (18.19.0), python3 (3.11.2-1), openjdk-17-jre
+- **Compiler**: gcc-arm-none-eabi
+- **Build Tools**: cmake, build-essential
+- **Debugging**: gdb-multiarch, openocd
+- **Code Quality**: cppcheck, uncrustify, flawfinder
+- **Documentation**: doxygen
+- **Runtime**: nodejs, python3, openjdk-jre-headless
 
 **VS Code Extensions** (auto-installed):
 - **C/C++ Development**: ms-vscode.cpptools, ms-vscode.cpptools-extension-pack
@@ -115,7 +131,7 @@ The development container provides a complete embedded development environment:
 export PICO_SDK_PATH="${containerWorkspaceFolder}/lib/pico-sdk"
 export FREERTOS_KERNEL_PATH="${containerWorkspaceFolder}/lib/FreeRTOS-Kernel"
 export PICO_TOOLCHAIN_PATH="/usr/bin"
-export JAVA_HOME="/usr/lib/jvm/java-17-openjdk-arm64"
+export JAVA_HOME="/usr/lib/jvm/java-openjdk-arm64"
 ```
 
 ## ✨ Features (Current Implementation)
@@ -434,7 +450,7 @@ All code is automatically formatted using Uncrustify with the provided `uncrusti
 **Build Issues:**
 - **Submodules not initialized**: Run `git submodule update --init --recursive`
 - **ARM toolchain not found**: Use DevContainer or install gcc-arm-none-eabi
-- **CMake version too old**: Minimum version 3.14 required
+- **CMake version too old**: Update CMake to a supported version
 
 **Runtime Issues:**
 - **USB not recognized**: Ensure TinyUSB CDC drivers installed on host


### PR DESCRIPTION
## Summary
- document project layout and helper scripts
- refresh DevContainer info: Debian base image, toolset, Java
- remove specific tool version numbers to keep setup instructions evergreen
- sync manual setup and env vars with current dependencies

## Testing
- `./scripts/analyze_memory.sh build/src/pi_controller.elf some_var` *(fails: arm-none-eabi-readelf: command not found)*
- `./scripts/memory_analysis.sh` *(fails: build/src/pi_controller.elf not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a788143290832fa727df4f39c1d171