### PR TITLE
chore: restrict dependabot submodule updates to tags

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    versioning-strategy: increase


### PR DESCRIPTION
## Summary
- ensure dependabot only updates submodules when new tags are released

## Testing
- `cmake -S . -B build` *(fails: include could not find requested file lib/pico-sdk/pico_sdk_init.cmake; Require minimum SDK version 1.5.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a837a84894832f96538b36a8484e26