### PR TITLE
chore: disable dependabot for submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,3 @@ updates:
     directory: "/.devcontainer"
     schedule:
       interval: "weekly"
-
-  - package-ecosystem: "gitsubmodule"
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
## Summary
- remove Dependabot configuration for git submodule updates that only work with tags

## Testing
- `cmake -S . -B build` *(fails: include could not find requested file: lib/pico-sdk/pico_sdk_init.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c492607c832fbadb046852a51c40