### PR TITLE
Add coverage instrumentation and extend unit tests

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,12 @@ add_library(signalbridge_core STATIC
 
 target_include_directories(signalbridge_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 
+# Enable coverage instrumentation when requested for GNU compilers
+if(ENABLE_COVERAGE AND CMAKE_C_COMPILER_ID MATCHES "GNU")
+    target_compile_options(signalbridge_core PUBLIC --coverage -fprofile-arcs -ftest-coverage)
+    target_link_libraries(signalbridge_core PUBLIC gcov)
+endif()
+
 # Add platform-specific dependencies to core library
 if(PICO_PLATFORM)
     # Pico target: Use RP2040 port and Pico SDK

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -15,11 +15,14 @@ add_unit_test(test_cobs
 add_unit_test(test_inputs
     test_inputs.c
     hardware_mocks.c
+    WRAP_FUNCTIONS gpio_put
 )
 
-# Test for outputs module (constant validation)
+# Test for outputs module (constant validation and simple behavior)
 add_unit_test(test_outputs
     test_outputs.c
+    hardware_mocks.c
+    WRAP_FUNCTIONS pwm_set_gpio_level
 )
 
 # Test for tm1639 module (constant validation)

--- a/test/unit/hardware_mocks.c
+++ b/test/unit/hardware_mocks.c
@@ -6,6 +6,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdarg.h>
+#include <stddef.h>
+#include "hardware/pwm.h"
 
 // Pico SDK mock types and functions
 typedef struct {
@@ -45,11 +47,14 @@ uint16_t adc_read(void) { return 0; }
 // PWM functions
 uint32_t pwm_gpio_to_slice_num(uint32_t gpio) { (void)gpio; return 0; }
 void pwm_set_wrap(uint32_t slice, uint16_t wrap) { (void)slice; (void)wrap; }
-void pwm_set_chan_level(uint32_t slice, uint32_t chan, uint16_t level) { 
-    (void)slice; (void)chan; (void)level; 
+void pwm_set_chan_level(uint32_t slice, uint32_t chan, uint16_t level) {
+    (void)slice; (void)chan; (void)level;
 }
 void pwm_set_enabled(uint32_t slice, bool enabled) { (void)slice; (void)enabled; }
 uint32_t pwm_gpio_to_channel(uint32_t gpio) { (void)gpio; return 0; }
+pwm_config pwm_get_default_config(void) { pwm_config cfg = {0}; return cfg; }
+void pwm_config_set_clkdiv(pwm_config *config, float div) { (void)config; (void)div; }
+void pwm_init(uint32_t slice_num, pwm_config *config, bool start) { (void)slice_num; (void)config; (void)start; }
 
 // SPI functions
 typedef struct spi_inst {
@@ -63,6 +68,7 @@ void spi_set_format(spi_inst_t *spi, uint32_t data_bits, uint32_t cpol, uint32_t
     (void)spi; (void)data_bits; (void)cpol; (void)cpha; (void)order;
 }
 void gpio_set_function(uint32_t gpio, uint32_t fn) { (void)gpio; (void)fn; }
+int spi_write_blocking(spi_inst_t *spi, const uint8_t *src, size_t len) { (void)spi; (void)src; return (int)len; }
 
 // FreeRTOS real implementation now used - no more mocks needed
 
@@ -70,3 +76,15 @@ void gpio_set_function(uint32_t gpio, uint32_t fn) { (void)gpio; (void)fn; }
 #define PICO_DEFAULT_LED_PIN 25
 #define GPIO_OUT true
 #define GPIO_IN false
+
+uint32_t gpio_get_function(uint32_t gpio) { (void)gpio; return 0; }
+void gpio_pull_up(uint32_t gpio) { (void)gpio; }
+void sleep_us(uint64_t us) { (void)us; }
+
+typedef struct uart_inst {
+    int dummy;
+} uart_inst_t;
+static uart_inst_t mock_uart_inst_uart0 = {0};
+uart_inst_t *uart0 = &mock_uart_inst_uart0;
+void uart_init(uart_inst_t *uart, uint32_t baudrate) { (void)uart; (void)baudrate; }
+void uart_set_fifo_enabled(uart_inst_t *uart, bool enabled) { (void)uart; (void)enabled; }

--- a/test/unit/test_inputs.c
+++ b/test/unit/test_inputs.c
@@ -205,6 +205,28 @@ static void test_input_init_minimal_valid_config(void **state)
     assert_int_equal(INPUT_OK, result);
 }
 
+// Wrapper to intercept gpio_put calls
+void __wrap_gpio_put(uint pin, bool value)
+{
+    check_expected(pin);
+    check_expected(value);
+}
+
+static void test_adc_mux_select(void **state)
+{
+    (void) state;
+    // Expect each pin to be set according to channel bits (0x0F)
+    expect_value(__wrap_gpio_put, pin, ADC_MUX_A);
+    expect_value(__wrap_gpio_put, value, true);
+    expect_value(__wrap_gpio_put, pin, ADC_MUX_B);
+    expect_value(__wrap_gpio_put, value, true);
+    expect_value(__wrap_gpio_put, pin, ADC_MUX_C);
+    expect_value(__wrap_gpio_put, value, true);
+    expect_value(__wrap_gpio_put, pin, ADC_MUX_D);
+    expect_value(__wrap_gpio_put, value, true);
+    adc_mux_select(0x0F);
+}
+
 int main(void) 
 {
     const struct CMUnitTest tests[] = {
@@ -218,6 +240,7 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_input_init_null_queue, setup, teardown),
         cmocka_unit_test_setup_teardown(test_input_init_boundary_valid_values, setup, teardown),
         cmocka_unit_test_setup_teardown(test_input_init_minimal_valid_config, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_adc_mux_select, setup, teardown),
     };
     
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/test/unit/test_outputs.c
+++ b/test/unit/test_outputs.c
@@ -8,6 +8,7 @@
 #include <setjmp.h>
 #include <cmocka.h>
 #include "outputs.h"
+#include "hardware/pwm.h"
 
 // No hardware calls in these tests; rely on headers only
 
@@ -121,6 +122,22 @@ static void test_gpio_count_constant(void **state)
     assert_true(NUM_GPIO > 0);
 }
 
+// Wrapper for pwm_set_gpio_level to capture arguments
+void __wrap_pwm_set_gpio_level(uint pin, uint16_t level)
+{
+    check_expected(pin);
+    check_expected(level);
+}
+
+static void test_set_pwm_duty(void **state)
+{
+    (void) state;
+    uint8_t duty = 5;
+    expect_value(__wrap_pwm_set_gpio_level, pin, PWM_PIN);
+    expect_value(__wrap_pwm_set_gpio_level, level, duty * duty);
+    set_pwm_duty(duty);
+}
+
 int main(void) 
 {
     const struct CMUnitTest tests[] = {
@@ -132,6 +149,7 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_device_config_valid_values, setup, teardown),
         cmocka_unit_test_setup_teardown(test_pin_uniqueness, setup, teardown),
         cmocka_unit_test_setup_teardown(test_gpio_count_constant, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_set_pwm_duty, setup, teardown),
     };
     
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
## Summary
- instrument core library for gcov when ENABLE_COVERAGE is set
- expand hardware mocks to satisfy output dependencies
- add unit tests for PWM duty helper and ADC mux selection

## Testing
- `cd build && ctest --output-on-failure`
- `cd build && lcov --summary coverage.info`

------
https://chatgpt.com/codex/tasks/task_e_68b366313878832fa6b5d8c9849da9be