### PR TITLE
Add unit tests with coverage reporting

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -5,17 +5,18 @@ on:
   push:
     paths:
       - 'src/**'
-      - 'include/**' 
+      - 'include/**'
+      - 'test/**'
       - '.gitmodules'
       - 'CMakeLists.txt'
       - '*.cmake'
+      - 'CMakePresets.json'
       - '.devcontainer/**'
   release:
     types: [published]
   workflow_dispatch:
 
 env:
-  BUILD_TYPE: Release
   PICO_PLATFORM: rp2040
   PICO_BOARD: pico
   PICO_SDK_PATH: ./lib/pico-sdk
@@ -45,9 +46,11 @@ jobs:
             firmware:
               - 'src/**'
               - 'include/**'
+              - 'test/**'
               - '.gitmodules'
               - 'CMakeLists.txt'
               - '*.cmake'
+              - 'CMakePresets.json'
 
   build-devcontainer:
     name: Build DevContainer
@@ -177,26 +180,8 @@ jobs:
           find . -name "CMakeLists.txt" -type f 2>/dev/null
           echo "=========================================================="
 
-      # Create build directory
-      - name: Create Build Environment
-        run: |
-          echo "Creating build directory..."
-          mkdir -p build
-          echo "Build directory created."
-
-      # Debug build directory
-      - name: Debug - Show build directory status
-        run: |
-          echo "=== Build Directory Status ==="
-          ls -la
-          echo "=== Build Directory Contents ==="
-          ls -la build/
-          echo "=== Current working directory ==="
-          pwd
-
-      # Configure CMake with detailed output
+      # Configure project using CMake presets
       - name: Configure CMake
-        shell: bash
         run: |
           echo "==================== CMAKE CONFIGURATION ===================="
           echo "Current directory: $(pwd)"
@@ -222,42 +207,34 @@ jobs:
             echo "❌ FREERTOS_KERNEL_PATH does not exist: ${{ env.FREERTOS_KERNEL_PATH }}"
           fi
           echo ""
-          echo "=== Running CMake from project root ==="
-          cmake -S . -B build \
-            -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-            -DPICO_SDK_PATH=${{ env.PICO_SDK_PATH }} \
-            -DFREERTOS_KERNEL_PATH=${{ env.FREERTOS_KERNEL_PATH }} \
-            -DPICO_TOOLCHAIN_PATH=${{ env.PICO_TOOLCHAIN_PATH }} \
-            -DCMAKE_VERBOSE_MAKEFILE=ON \
-            --debug-output
+          echo "=== Running CMake with preset ==="
+          cmake --preset pico-release --debug-output
           echo "=========================================================="
 
-      # Build the project
+      # Build the project using presets
       - name: Build
-        working-directory: build
-        shell: bash
         run: |
           echo "==================== BUILDING PROJECT ===================="
           echo "Starting build process..."
-          cmake --build . --config $BUILD_TYPE --verbose
+          cmake --build --preset pico-release --verbose
           echo ""
           echo "=== Build completed - checking outputs ==="
-          find . -name "*.uf2" -o -name "*.elf" -o -name "*.bin" -o -name "*.hex" 2>/dev/null
+          find build-release -name "*.uf2" -o -name "*.elf" -o -name "*.bin" -o -name "*.hex" 2>/dev/null
           echo "=========================================================="
 
       # Archive documentation if it exists
       - name: Archive Doxygen Documentation
         run: |
           echo "==================== DOCUMENTATION ===================="
-          if [ -d "build/docs/doc_doxygen" ]; then
+          if [ -d "build-release/docs/doc_doxygen" ]; then
             echo "✅ Doxygen documentation found"
             echo "Creating documentation archive..."
-            tar -czf build/src/doc.tar.gz -C build/docs/ doc_doxygen
+            tar -czf build-release/src/doc.tar.gz -C build-release/docs/ doc_doxygen
             echo "Documentation archived successfully"
           else
             echo "ℹ️  Doxygen documentation not found, skipping archive"
             echo "Available directories in build:"
-            find build -type d -name "*doc*" 2>/dev/null || echo "No documentation directories found"
+            find build-release -type d -name "*doc*" 2>/dev/null || echo "No documentation directories found"
           fi
           echo "=========================================================="
 
@@ -266,10 +243,10 @@ jobs:
         run: |
           echo "==================== ARTIFACTS ===================="
           echo "=== Looking for build artifacts ==="
-          find build -name "*.uf2" -o -name "*.elf" -o -name "*.bin" -o -name "*.hex" 2>/dev/null
+          find build-release -name "*.uf2" -o -name "*.elf" -o -name "*.bin" -o -name "*.hex" 2>/dev/null
           echo ""
           echo "=== Build directory structure ==="
-          find build -type f | head -20
+          find build-release -type f | head -20
           echo "=========================================================="
 
       # Store build artifacts
@@ -278,10 +255,55 @@ jobs:
         with:
           name: pico-build
           path: |
-            build/src/*.uf2
-            build/src/*.elf
-            build/src/doc.tar.gz
+            build-release/src/*.uf2
+            build-release/src/*.elf
+            build-release/src/doc.tar.gz
           retention-days: 10
+
+  unit-tests:
+    name: Run Unit Tests
+    runs-on: ubuntu-latest
+    needs: [detect-changes, build-devcontainer]
+    if: |
+      (needs.detect-changes.outputs.firmware-changed == 'true' ||
+       needs.detect-changes.outputs.devcontainer-changed == 'true' ||
+       github.event_name == 'workflow_dispatch') &&
+      (needs.build-devcontainer.result == 'success' || needs.build-devcontainer.result == 'skipped')
+    container:
+      image: ${{ needs.build-devcontainer.outputs.image-tag || format('ghcr.io/{0}/devcontainer-embedded-debian:latest', github.repository) }}
+      options: --user=root
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Configure tests
+        run: cmake --preset host-tests
+
+      - name: Build tests
+        run: cmake --build --preset host-tests
+
+      - name: Run tests
+        run: ctest --preset host-tests
+
+      - name: Generate coverage
+        run: cmake --build --preset host-tests-coverage
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: build-tests/coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: build-tests/coverage.info
+          flags: unittests
 
   # Release job (only runs on releases)
   release:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 # Signalbridge - Controller Firmware
 
 ![build](https://github.com/carlosmazzei/signalbridge-controller/actions/workflows/build-all.yml/badge.svg)
+[![Coverage](https://codecov.io/gh/carlosmazzei/signalbridge-controller/branch/main/graph/badge.svg)](https://codecov.io/gh/carlosmazzei/signalbridge-controller)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![DevContainer](https://img.shields.io/badge/DevContainer-Ready-green.svg)](https://code.visualstudio.com/docs/remote/containers)
 


### PR DESCRIPTION
## Summary
- run unit tests with coverage in GitHub Actions using the project devcontainer
- upload coverage results to Codecov and expose as badge
- switch workflow to CMake presets for firmware and host-test builds

## Testing
- `cmake --preset host-tests`
- `cmake --build --preset host-tests`
- `ctest --preset host-tests`
- `cmake --build --preset host-tests-coverage`


------
https://chatgpt.com/codex/tasks/task_e_68b4db4c5708832fb2eb2aefc9f09e3c