### PR TITLE
ci: add Codecov token

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -302,6 +302,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: build-tests/coverage.info
           flags: unittests
 


### PR DESCRIPTION
## Summary
- pass Codecov token from repository secrets in coverage upload step

## Testing
- `actionlint .github/workflows/build-all.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b4e53efe98832f8bb3af0f50e1a165