### PR TITLE
Fix CDC COBS boundary check and tighten max-payload test

### DIFF
--- a/src/app_comm.c
+++ b/src/app_comm.c
@@ -147,7 +147,7 @@ static void send_heap_status(uint8_t index)
 
 void app_comm_send_packet(uint16_t id, uint8_t command, const uint8_t *send_data, uint8_t length)
 {
-	uint8_t uart_outbound_buffer[DATA_BUFFER_SIZE];
+	uint8_t uart_outbound_buffer[MESSAGE_SIZE];
 	bool error = false;
 
 	if (NULL == send_data)
@@ -156,7 +156,7 @@ void app_comm_send_packet(uint16_t id, uint8_t command, const uint8_t *send_data
 		error = true;
 	}
 
-	if ((!error) && (length > (DATA_BUFFER_SIZE - HEADER_SIZE - CHECKSUM_SIZE)))
+	if ((!error) && (length > DATA_BUFFER_SIZE))
 	{
 		statistics_increment_counter(BUFFER_OVERFLOW_ERROR);
 		error = true;
@@ -180,7 +180,7 @@ void app_comm_send_packet(uint16_t id, uint8_t command, const uint8_t *send_data
 		                                       (size_t)length + HEADER_SIZE + CHECKSUM_SIZE,
 		                                       encode_buffer);
 
-		if ((num_encoded + 1U) >= MAX_ENCODED_BUFFER_SIZE)
+		if ((num_encoded + 1U) > MAX_ENCODED_BUFFER_SIZE)
 		{
 			statistics_increment_counter(BUFFER_OVERFLOW_ERROR);
 		}

--- a/test/FreeRTOSConfig.h
+++ b/test/FreeRTOSConfig.h
@@ -50,7 +50,7 @@
 #define configUSE_DAEMON_TASK_STARTUP_HOOK      0
 
 // Run time and task stats gathering related definitions.
-#define configGENERATE_RUN_TIME_STATS           0
+#define configGENERATE_RUN_TIME_STATS           1
 #define configUSE_TRACE_FACILITY                1
 #define configUSE_STATS_FORMATTING_FUNCTIONS    0
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -40,6 +40,7 @@ add_unit_test(test_tm1637
 add_unit_test(test_app_comm
     test_app_comm.c
     ${CMAKE_CURRENT_SOURCE_DIR}/../../src/app_comm.c
+    hardware_mocks.c
     WRAP_FUNCTIONS xQueueGenericSend
 )
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -36,6 +36,13 @@ add_unit_test(test_tm1637
     hardware_mocks.c
 )
 
+# Test for app_comm module (CDC packet sizing)
+add_unit_test(test_app_comm
+    test_app_comm.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src/app_comm.c
+    WRAP_FUNCTIONS xQueueGenericSend
+)
+
 # Standalone COBS test (no hardware dependencies)
 add_executable(test_cobs_standalone test_cobs_standalone.c)
 target_link_libraries(test_cobs_standalone ${CMOCKA_LIBRARIES})

--- a/test/unit/hardware_mocks.c
+++ b/test/unit/hardware_mocks.c
@@ -76,6 +76,7 @@ void pwm_set_wrap(uint32_t slice, uint16_t wrap) { (void)slice; (void)wrap; }
 void pwm_set_chan_level(uint32_t slice, uint32_t chan, uint16_t level) {
     (void)slice; (void)chan; (void)level;
 }
+void pwm_set_gpio_level(uint pin, uint16_t level) { (void)pin; (void)level; }
 void pwm_set_enabled(uint32_t slice, bool enabled) { (void)slice; (void)enabled; }
 uint32_t pwm_gpio_to_channel(uint32_t gpio) { (void)gpio; return 0; }
 pwm_config pwm_get_default_config(void) { pwm_config cfg = {0}; return cfg; }
@@ -97,6 +98,10 @@ void gpio_set_function(uint32_t gpio, uint32_t fn) { (void)gpio; (void)fn; }
 int spi_write_blocking(spi_inst_t *spi, const uint8_t *src, size_t len) { (void)spi; (void)src; return (int)len; }
 
 // FreeRTOS real implementation now used - no more mocks needed
+size_t xPortGetMinimumEverFreeHeapSize(void)
+{
+    return 0U;
+}
 
 // Constants
 #define PICO_DEFAULT_LED_PIN 25

--- a/test/unit/test_app_comm.c
+++ b/test/unit/test_app_comm.c
@@ -1,0 +1,94 @@
+/**
+ * @file test_app_comm.c
+ * @brief Unit tests for app_comm module
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <string.h>
+
+#include <cmocka.h>
+
+#include "FreeRTOS.h"
+#include "queue.h"
+
+#include "app_comm.h"
+#include "app_context.h"
+#include "commands.h"
+#include "error_management.h"
+
+static QueueHandle_t mock_queue_handle = (QueueHandle_t)0xCAFEU;
+static BaseType_t mock_queue_result = pdTRUE;
+static int mock_queue_send_calls = 0;
+static cdc_packet_t captured_packet;
+
+BaseType_t __wrap_xQueueGenericSend(QueueHandle_t xQueue,
+                                    const void *pvItemToQueue,
+                                    TickType_t xTicksToWait,
+                                    BaseType_t xCopyPosition)
+{
+	(void)xTicksToWait;
+	(void)xCopyPosition;
+
+	assert_ptr_equal(xQueue, mock_queue_handle);
+	mock_queue_send_calls++;
+
+	if (pvItemToQueue != NULL)
+	{
+		memcpy(&captured_packet, pvItemToQueue, sizeof(cdc_packet_t));
+	}
+
+	return mock_queue_result;
+}
+
+static int setup_test(void **state)
+{
+	(void)state;
+	mock_queue_send_calls = 0;
+	memset(&captured_packet, 0, sizeof(captured_packet));
+	mock_queue_result = pdTRUE;
+	statistics_reset_all_counters();
+	app_context_set_cdc_transmit_queue(mock_queue_handle);
+	return 0;
+}
+
+static void test_send_packet_accepts_max_payload(void **state)
+{
+	(void)state;
+	uint8_t payload[DATA_BUFFER_SIZE];
+	for (uint8_t i = 0U; i < DATA_BUFFER_SIZE; i++)
+	{
+		payload[i] = (uint8_t)(i + 1U);
+	}
+
+	app_comm_send_packet(BOARD_ID, PC_ECHO_CMD, payload, DATA_BUFFER_SIZE);
+
+	assert_int_equal(mock_queue_send_calls, 1);
+	assert_int_equal(statistics_get_counter(BUFFER_OVERFLOW_ERROR), 0);
+	assert_true(captured_packet.length > 0U);
+	assert_true(captured_packet.length <= MAX_ENCODED_BUFFER_SIZE);
+	assert_int_equal(captured_packet.length, MAX_ENCODED_BUFFER_SIZE);
+}
+
+static void test_send_packet_rejects_oversized_payload(void **state)
+{
+	(void)state;
+	uint8_t payload[DATA_BUFFER_SIZE + 1U];
+	memset(payload, 0xA5, sizeof(payload));
+
+	app_comm_send_packet(BOARD_ID, PC_ECHO_CMD, payload, (uint8_t)(DATA_BUFFER_SIZE + 1U));
+
+	assert_int_equal(mock_queue_send_calls, 0);
+	assert_int_equal(statistics_get_counter(BUFFER_OVERFLOW_ERROR), 1);
+}
+
+int main(void)
+{
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test_setup(test_send_packet_accepts_max_payload, setup_test),
+		cmocka_unit_test_setup(test_send_packet_rejects_oversized_payload, setup_test),
+	};
+
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
### Motivation
- The COBS encoding boundary check in the CDC outbound path was incorrectly treating a packet that exactly filled the encoded buffer as an overflow, preventing legitimate max-size packets from being sent.
- Unit tests were added to document max-payload and oversized-payload behavior and needed to assert the exact boundary condition.
- Ensure the code accepts a payload that encodes to exactly `MAX_ENCODED_BUFFER_SIZE` bytes and only flags overflow when the encoded output would exceed that size.

### Description
- Change the overflow check in `src/app_comm.c` to use `if ((num_encoded + 1U) > MAX_ENCODED_BUFFER_SIZE)` so a full-fill encoding is allowed.  
- Tighten the unit test in `test/unit/test_app_comm.c` to assert `captured_packet.length == MAX_ENCODED_BUFFER_SIZE`.  
- The PR builds on earlier changes that allocate the outbound staging buffer as `MESSAGE_SIZE`, simplify the payload length guard to allow full `DATA_BUFFER_SIZE` payloads, and register the `test_app_comm` unit test in `test/unit/CMakeLists.txt`.

### Testing
- Ran `cmake --preset host-tests`, which failed to configure due to missing `cmocka` (unit tests could not be executed).  
- Ran `./scripts/cppcheck_simple.sh`, which completed but could not run `cppcheck` because it is not installed in the environment.  
- No automated unit tests were executed in this environment due to the missing test dependencies; the new/updated tests are present and ready to run in CI or a dev environment with `cmocka` and `cppcheck` installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69886982d260832f9710e3c590f6e523)