### PR TITLE
fix(inputs): correct keypad scan timing and fix row 0 spurious events

### DIFF
--- a/.devcontainer/dependencies.json
+++ b/.devcontainer/dependencies.json
@@ -13,7 +13,7 @@
     "git": "1:2.47.3-0+deb13u1",
     "libnewlib-arm-none-eabi": "4.5.0.20241231-1",
     "libstdc++-arm-none-eabi-newlib": "15:14.2.rel1-1+29",
-    "nodejs": "20.19.2+dfsg-1+deb13u1",
+    "nodejs": "20.19.2+dfsg-1+deb13u2",
     "openjdk-21-jre-headless": "21.0.10+7-1~deb13u1",
     "openssh-client": "1:10.0p1-7+deb13u1",
     "python3": "3.13.5-1",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -72,4 +72,5 @@
         "connectionId": "carlosmazzei",
         "projectKey": "carlosmazzei_signalbridge-controller"
     },
+    "C_Cpp.errorSquiggles": "enabled",
 }

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ If containers are not available, install CMake, Doxygen, Python 3, the GNU Arm E
 - Queues sized per `include/app_config.h`: encoded reception queue (2048 bytes), CDC transmit queue (2048 packets), and data event queue (500 events).
 
 ### Input subsystem
-- Eight-by-eight keypad matrix with three-bit stability masks for debouncing and configurable settling delays.
+- Eight-by-eight keypad matrix with three-bit stability masks for debouncing. The scan loop uses separate hardware-settling parameters for the 74HC138 column decoder (`col_mux_settling_us`, default 1 µs) and the 74HC4051 row multiplexer (`row_mux_settling_us`, default 1 µs); the full matrix is scanned in under 100 µs per cycle. A configurable scan-cycle interval (`key_settling_time_ms`, default 10 ms) is applied once per full scan and defines the debounce window: window = `key_settling_time_ms` × number of required stable samples (2 × 10 ms = 20 ms with the default three-bit mask).
 - Sixteen ADC channels behind a four-bit multiplexer with moving-average filtering to smooth readings.
 - Up to eight rotary encoders controlled through a run-time mask and independent sampling delays.
 - GPIO assignments from `include/app_inputs.h`: keypad multiplexers on GPIO 0/1/2/17 and 6/7/3/8, ADC multiplexer selects on GPIO 20/21/22/11, and keypad sampling on GPIO 9.

--- a/include/app_inputs.h
+++ b/include/app_inputs.h
@@ -108,12 +108,14 @@ typedef struct input_config_t
 {
 	uint8_t rows;                             /**< Number of keypad rows to scan. */
 	uint8_t columns;                          /**< Number of keypad columns to scan. */
-	uint16_t key_settling_time_ms;            /**< Debounce delay applied between column selects. */
+	uint16_t key_settling_time_ms;            /**< Scan-cycle interval (ms); debounce window = key_settling_time_ms * required samples. */
 	uint8_t adc_channels;                     /**< Number of ADC channels populated on the board. */
 	uint16_t adc_settling_time_ms;            /**< Delay between ADC channel selections. */
 	QueueHandle_t input_event_queue;          /**< Destination queue for generated events. */
 	bool encoder_mask[MAX_NUM_ENCODERS];      /**< Bitmap flagging which rows host encoders. */
 	uint16_t encoder_settling_time_ms;        /**< Delay between encoder samples. */
+	uint16_t col_mux_settling_us;             /**< 74HC138 column decoder propagation settling delay (µs). */
+	uint16_t row_mux_settling_us;             /**< 74HC4051 row MUX enable settling delay (µs). */
 } input_config_t;
 
 /**

--- a/src/app_inputs.c
+++ b/src/app_inputs.c
@@ -28,11 +28,13 @@
 static input_config_t input_config = {
 	.columns                  = 8,
 	.rows                     = 8,
-	.key_settling_time_ms     = 20,
+	.key_settling_time_ms     = 10,
 	.adc_channels             = 16,
 	.adc_settling_time_ms     = 100,
 	.encoder_settling_time_ms = 10,
-	.encoder_mask             = { [7] = true }
+	.encoder_mask             = { [7] = true },
+	.col_mux_settling_us      = 1U,  /* 74HC138: tPD ~12 ns; 1 µs provides 83x margin */
+	.row_mux_settling_us      = 1U   /* 74HC4051: tEN ~100 ns; 1 µs provides 10x margin */
 };
 
 /**
@@ -213,8 +215,8 @@ void keypad_task(void *pvParameters)
 			keypad_set_columns(c);
 			keypad_cs_columns(true);
 
-			// Settle the column
-			vTaskDelay(pdMS_TO_TICKS(input_config.key_settling_time_ms));
+			// 74HC138 propagation settling
+			busy_wait_us_32(input_config.col_mux_settling_us);
 
 			for (uint8_t r = 0; r < input_config.rows; r++)
 			{
@@ -225,6 +227,9 @@ void keypad_task(void *pvParameters)
 
 				keypad_set_rows(r); // Also set the ADC channels
 				keypad_cs_rows(true);
+
+				// 74HC4051 enable settling before reading
+				busy_wait_us_32(input_config.row_mux_settling_us);
 
 				uint8_t keycode = keypad_index(r, c);
 				bool pressed = !gpio_get(KEYPAD_ROW_INPUT); // Active low pin
@@ -246,6 +251,9 @@ void keypad_task(void *pvParameters)
 
 		task_props->high_watermark = uxTaskGetStackHighWaterMark(NULL);
 		watchdog_update();
+
+		// Scan-cycle interval: controls debounce window (window = key_settling_time_ms * required samples)
+		vTaskDelay(pdMS_TO_TICKS(input_config.key_settling_time_ms));
 	}
 }
 

--- a/test/unit/hardware_mocks.c
+++ b/test/unit/hardware_mocks.c
@@ -45,6 +45,7 @@ void mock_time_config(uint32_t initial_value, uint32_t step)
 }
 
 void busy_wait_ms(uint32_t ms) { (void)ms; }
+void busy_wait_us_32(uint32_t delay_us) { (void)delay_us; }
 uint32_t time_us_32(void)
 {
     uint32_t now = mock_time_current;

--- a/test/unit/mock_headers/pico/time.h
+++ b/test/unit/mock_headers/pico/time.h
@@ -5,6 +5,7 @@
 // Mock Pico time functions
 uint32_t time_us_32(void);
 void sleep_us(uint64_t us);
+void busy_wait_us_32(uint32_t delay_us);
 
 #ifndef pdMS_TO_TICKS
 #define pdMS_TO_TICKS(ms) (ms)  // Simple mapping for tests


### PR DESCRIPTION
## Summary

- **Root cause**: `vTaskDelay(key_settling_time_ms)` was placed after column CS assertion (once per column), leaving the 74HC4051 row MUX CS deasserted — and `KEYPAD_ROW_INPUT` floating — for the entire wait. Row 0 is always the first row read after this window, producing inconsistent samples that matched both `KEY_PRESSED_MASK` and `KEY_RELEASED_MASK` spuriously. Rows 1–7 were unaffected because the row MUX CS was only briefly deasserted between consecutive rows (< 1 µs).
- **Fix**: Added separate hardware-settling delays for the 74HC138 column decoder (`col_mux_settling_us`, 1 µs) and the 74HC4051 row MUX (`row_mux_settling_us`, 1 µs) using `busy_wait_us_32`. Moved the `vTaskDelay` to the bottom of the `while(true)` loop so `key_settling_time_ms` correctly serves as the scan-cycle interval (debounce window = `key_settling_time_ms × 2 samples`).
- **Tuning**: Reduced `key_settling_time_ms` default from 20 ms to 10 ms → 20 ms debounce window, 100 Hz scan rate, full matrix scanned in < 100 µs per cycle.

## Test plan

- [ ] Build firmware: `cmake --preset pico-debug && cmake --build --preset pico-debug`
- [ ] Flash to Pico and run the monitor — confirm row 0 is stable with no keys pressed
- [ ] Press each row-0 key — confirm clean single press/release events
- [ ] Confirm all other rows and columns behave correctly
- [ ] Run unit tests: `ctest --preset host-tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)