### PR TITLE
feat(encoders): add per-position rotary encoder mapping via keypad matrix

### DIFF
--- a/.cppcheck_suppressions
+++ b/.cppcheck_suppressions
@@ -35,7 +35,7 @@ misra-c2012-8.4:*src/error_management.c:168             # typedef needed for cla
 
 # Specific function suppressions for false positives
 unusedFunction:*src/app_comm.c:30                       # Used by TinyUSB stack
-unusedFunction:*src/app_inputs.c:470                    # Used by app_outputs
+unusedFunction:*src/app_inputs.c:560                    # Used by app_outputs
 unusedFunction:*src/tm1637.c:300                        # Used by app_outputs
 unusedFunction:*src/tm1637.c:660                        # Used by app_outputs
 unusedFunction:*src/tm1639.c:205                        # Used by app_outputs

--- a/include/app_inputs.h
+++ b/include/app_inputs.h
@@ -102,6 +102,20 @@
 /** @} */
 
 /**
+ * @brief Per-encoder position mapping within the keypad matrix.
+ *
+ * Each encoder occupies two adjacent columns (channel A at @c col,
+ * channel B at @c col + 1) on the specified @c row.  Mapped positions
+ * are excluded from keypad scanning automatically.
+ */
+typedef struct encoder_map_t
+{
+	uint8_t row;     /**< Row index where this encoder is wired. */
+	uint8_t col;     /**< Base column index (channel A); channel B is col + 1. */
+	bool enabled;    /**< Whether this encoder mapping is active. */
+} encoder_map_t;
+
+/**
  * @brief Run-time configuration for the input subsystem.
  */
 typedef struct input_config_t
@@ -112,7 +126,8 @@ typedef struct input_config_t
 	uint8_t adc_channels;                     /**< Number of ADC channels populated on the board. */
 	uint16_t adc_settling_time_ms;            /**< Delay between ADC channel selections. */
 	QueueHandle_t input_event_queue;          /**< Destination queue for generated events. */
-	bool encoder_mask[MAX_NUM_ENCODERS];      /**< Bitmap flagging which rows host encoders. */
+	encoder_map_t encoder_map[MAX_NUM_ENCODERS]; /**< Per-encoder position mappings. */
+	uint8_t num_encoders;                     /**< Number of configured encoder entries. */
 	uint16_t encoder_settling_time_ms;        /**< Delay between encoder samples. */
 	uint16_t col_mux_settling_us;             /**< 74HC138 column decoder propagation settling delay (µs). */
 	uint16_t row_mux_settling_us;             /**< 74HC4051 row MUX enable settling delay (µs). */
@@ -183,5 +198,17 @@ void adc_read_task(void *pvParameters);
  * @param[in,out] pvParameters Pointer to the owning @ref task_props_t instance.
  */
 void encoder_read_task(void *pvParameters);
+
+/**
+ * @brief Query whether a keypad matrix position is mapped to an encoder.
+ *
+ * @param[in] row Row index to check.
+ * @param[in] col Column index to check.
+ *
+ * @retval true  The position is part of an encoder pair and is excluded
+ *               from keypad scanning.
+ * @retval false The position is a regular key.
+ */
+bool input_is_encoder_position(uint8_t row, uint8_t col);
 
 #endif // KEYPAD_H

--- a/include/app_inputs.h
+++ b/include/app_inputs.h
@@ -128,7 +128,6 @@ typedef struct input_config_t
 	QueueHandle_t input_event_queue;          /**< Destination queue for generated events. */
 	encoder_map_t encoder_map[MAX_NUM_ENCODERS]; /**< Per-encoder position mappings. */
 	uint8_t num_encoders;                     /**< Number of configured encoder entries. */
-	uint16_t encoder_settling_time_ms;        /**< Delay between encoder samples. */
 	uint16_t col_mux_settling_us;             /**< 74HC138 column decoder propagation settling delay (µs). */
 	uint16_t row_mux_settling_us;             /**< 74HC4051 row MUX enable settling delay (µs). */
 } input_config_t;

--- a/src/app_inputs.c
+++ b/src/app_inputs.c
@@ -32,7 +32,13 @@ static input_config_t input_config = {
 	.adc_channels             = 16,
 	.adc_settling_time_ms     = 100,
 	.encoder_settling_time_ms = 10,
-	.encoder_mask             = { [7] = true },
+	.num_encoders             = 4U,
+	.encoder_map              = {
+		{ .row = 7U, .col = 0U, .enabled = true },
+		{ .row = 7U, .col = 2U, .enabled = true },
+		{ .row = 7U, .col = 4U, .enabled = true },
+		{ .row = 7U, .col = 6U, .enabled = true },
+	},
 	.col_mux_settling_us      = 1U,  /* 74HC138: tPD ~12 ns; 1 µs provides 83x margin */
 	.row_mux_settling_us      = 1U   /* 74HC4051: tEN ~100 ns; 1 µs provides 10x margin */
 };
@@ -41,6 +47,32 @@ static input_config_t input_config = {
  * @brief State array for each key in the keypad matrix.
  */
 static uint8_t keypad_state[KEYPAD_ROWS * KEYPAD_COLUMNS];
+
+/**
+ * @brief Per-position lookup indicating which matrix cells are mapped to encoders.
+ *
+ * Built by @ref build_encoder_skip() from @ref input_config during @ref input_init().
+ * The keypad task consults this array to skip encoder-mapped positions.
+ */
+static bool encoder_skip[KEYPAD_ROWS][KEYPAD_COLUMNS];
+
+/**
+ * @brief Populate @ref encoder_skip from the current encoder map configuration.
+ */
+static void build_encoder_skip(void)
+{
+	(void)memset(encoder_skip, 0, sizeof(encoder_skip));
+	for (uint8_t i = 0U; i < input_config.num_encoders; i++)
+	{
+		if (input_config.encoder_map[i].enabled)
+		{
+			uint8_t r = input_config.encoder_map[i].row;
+			uint8_t c = input_config.encoder_map[i].col;
+			encoder_skip[r][c] = true;
+			encoder_skip[r][c + 1U] = true;
+		}
+	}
+}
 
 /**
  * @brief Check configuration parameters
@@ -61,6 +93,40 @@ static bool check_config_params(const input_config_t *config)
 	    (0U == config->encoder_settling_time_ms))
 	{
 		result = false;
+	}
+
+	if (config->num_encoders > MAX_NUM_ENCODERS)
+	{
+		result = false;
+	}
+
+	for (uint8_t i = 0U; (i < config->num_encoders) && result; i++)
+	{
+		if (config->encoder_map[i].enabled)
+		{
+			/* Channel B is at col + 1, so col + 1 must be < columns */
+			if ((config->encoder_map[i].row >= config->rows) ||
+			    ((config->encoder_map[i].col + 1U) >= config->columns))
+			{
+				result = false;
+			}
+
+			/* Reject overlapping positions on the same row */
+			for (uint8_t j = 0U; (j < i) && result; j++)
+			{
+				if (config->encoder_map[j].enabled &&
+				    (config->encoder_map[i].row == config->encoder_map[j].row))
+				{
+					uint8_t ci = config->encoder_map[i].col;
+					uint8_t cj = config->encoder_map[j].col;
+					uint8_t diff = (ci > cj) ? (ci - cj) : (cj - ci);
+					if (diff < 2U)
+					{
+						result = false;
+					}
+				}
+			}
+		}
 	}
 
 	return result;
@@ -93,6 +159,7 @@ input_result_t input_init(void)
 	{
 		// Initialize keypad configuration
 		(void)memset(keypad_state, 0, sizeof(keypad_state));
+		build_encoder_skip();
 
 		// Setup IO pins using gpio_init_mask to configure multiple pins at once
 		uint32_t gpio_mask = ((1UL << KEYPAD_COL_MUX_A) |
@@ -119,6 +186,11 @@ input_result_t input_init(void)
 	}
 
 	return result;
+}
+
+bool input_is_encoder_position(uint8_t row, uint8_t col)
+{
+	return encoder_skip[row][col];
 }
 
 /**
@@ -220,9 +292,9 @@ void keypad_task(void *pvParameters)
 
 			for (uint8_t r = 0; r < input_config.rows; r++)
 			{
-				if (true == input_config.encoder_mask[r])
+				if (encoder_skip[r][c])
 				{
-					continue; // Skip encoder
+					continue; /* Skip position mapped to an encoder */
 				}
 
 				keypad_set_rows(r); // Also set the ADC channels
@@ -402,12 +474,12 @@ static void encoder_generate_event(uint8_t rotary, uint16_t direction)
 
 void encoder_read_task(void *pvParameters)
 {
-	const int8_t encoder_states[] = {0, -1, 1, 0, 1, 0, 0, -1, -1, 0, 0, 1, 0, 1, -1, 0};
+	const int8_t encoder_lut[] = {0, -1, 1, 0, 1, 0, 0, -1, -1, 0, 0, 1, 0, 1, -1, 0};
 	encoder_states_t encoder_state[MAX_NUM_ENCODERS];
 
 	task_props_t * task_prop = (task_props_t*) pvParameters;
 
-	for (uint8_t i = 0; i < MAX_NUM_ENCODERS; i++)
+	for (uint8_t i = 0U; i < MAX_NUM_ENCODERS; i++)
 	{
 		encoder_state[i].old_encoder = 0;
 		encoder_state[i].count_encoder = 0;
@@ -415,59 +487,60 @@ void encoder_read_task(void *pvParameters)
 
 	while (true)
 	{
-		for (uint8_t r = 0; r < input_config.rows; r++)
+		for (uint8_t i = 0U; i < input_config.num_encoders; i++)
 		{
-			if (false == input_config.encoder_mask[r])
+			if (!input_config.encoder_map[i].enabled)
 			{
 				continue;
 			}
 
+			uint8_t r = input_config.encoder_map[i].row;
+			uint8_t c = input_config.encoder_map[i].col;
+
+			/* Select row */
 			keypad_cs_rows(true);
 			keypad_set_rows(r);
 
-			for (uint8_t c = 0U; c < (input_config.columns / 2U); c++)
-			{
-				uint8_t encoder_base = (uint8_t)(r * (input_config.columns / 2U)) + c;
-				keypad_cs_columns(true);
-				keypad_set_columns(c);
-				vTaskDelay(pdMS_TO_TICKS(input_config.encoder_settling_time_ms));
-				bool e11 = !gpio_get(KEYPAD_ROW_INPUT); // Active low pin
+			/* Read channel A */
+			keypad_cs_columns(true);
+			keypad_set_columns(c);
+			vTaskDelay(pdMS_TO_TICKS(input_config.encoder_settling_time_ms));
+			bool ch_a = !gpio_get(KEYPAD_ROW_INPUT); /* Active low pin */
 
-				keypad_set_columns(c + 1U);
-				vTaskDelay(pdMS_TO_TICKS(input_config.encoder_settling_time_ms));
-				bool e12 = !gpio_get(KEYPAD_ROW_INPUT); // Active low pin
+			/* Read channel B */
+			keypad_set_columns(c + 1U);
+			vTaskDelay(pdMS_TO_TICKS(input_config.encoder_settling_time_ms));
+			bool ch_b = !gpio_get(KEYPAD_ROW_INPUT); /* Active low pin */
 
-				/**
-				 * @par Calculate the encoder state
-				 * Remember previous state by shifting the lower bits up
-				 * AND the lower 2 bits of port a, then OR them with var old_Encoder1 to set new value
-				 * the lower 4 bits of old_Encoder1 are
-				 */
-				encoder_state[encoder_base].old_encoder <<= 2;
-				encoder_state[encoder_base].old_encoder |= (uint8_t)(e11 ? 1U : 0U);
-				encoder_state[encoder_base].old_encoder |= ((uint8_t)(e12 ? 1U : 0U) << 1U) & 0x03U;
-				encoder_state[encoder_base].count_encoder += encoder_states[encoder_state[encoder_base].old_encoder & 0x0FU];
-
-				if (4 == encoder_state[encoder_base].count_encoder)
-				{
-					encoder_generate_event(encoder_base, 1);
-					encoder_state[encoder_base].count_encoder = 0;
-				}
-				if (-4 == encoder_state[encoder_base].count_encoder)
-				{
-					encoder_generate_event(encoder_base, 0);
-					encoder_state[encoder_base].count_encoder = 0;
-				}
-
-				keypad_cs_columns(false);
-			}
-
+			keypad_cs_columns(false);
 			keypad_cs_rows(false);
+
+			/* Quadrature state machine: shift previous state, OR in new sample */
+			encoder_state[i].old_encoder <<= 2U;
+			encoder_state[i].old_encoder |= (uint8_t)(ch_a ? 1U : 0U);
+			encoder_state[i].old_encoder |= (uint8_t)((uint8_t)(ch_b ? 1U : 0U) << 1U) & 0x03U;
+			encoder_state[i].count_encoder += encoder_lut[encoder_state[i].old_encoder & 0x0FU];
+
+			if (4 == encoder_state[i].count_encoder)
+			{
+				encoder_generate_event(i, 1U);
+				encoder_state[i].count_encoder = 0;
+			}
+			if (-4 == encoder_state[i].count_encoder)
+			{
+				encoder_generate_event(i, 0U);
+				encoder_state[i].count_encoder = 0;
+			}
 		}
 
-		// Get free heap for the task
 		task_prop->high_watermark = uxTaskGetStackHighWaterMark(NULL);
 		watchdog_update();
+
+		/* When no encoders are configured, avoid busy-looping */
+		if (0U == input_config.num_encoders)
+		{
+			vTaskDelay(pdMS_TO_TICKS(input_config.encoder_settling_time_ms));
+		}
 	}
 }
 
@@ -486,8 +559,9 @@ void encoder_read_task(void *pvParameters)
  */
 static void encoder_set_mask(uint8_t mask)
 {
-	for (uint8_t i = 0; i < MAX_NUM_ENCODERS; i++)
+	for (uint8_t i = 0U; i < input_config.num_encoders; i++)
 	{
-		input_config.encoder_mask[i] = mask & (1U << i);
+		input_config.encoder_map[i].enabled = ((mask & (1U << i)) != 0U);
 	}
+	build_encoder_skip();
 }

--- a/src/app_inputs.c
+++ b/src/app_inputs.c
@@ -31,7 +31,6 @@ static input_config_t input_config = {
 	.key_settling_time_ms     = 10,
 	.adc_channels             = 16,
 	.adc_settling_time_ms     = 100,
-	.encoder_settling_time_ms = 10,
 	.num_encoders             = 4U,
 	.encoder_map              = {
 		{ .row = 7U, .col = 0U, .enabled = true },
@@ -89,8 +88,7 @@ static bool check_config_params(const input_config_t *config)
 	    (config->rows > KEYPAD_MAX_ROWS) ||
 	    (config->adc_channels > 16U) ||
 	    (0U == config->key_settling_time_ms) ||
-	    (0U == config->adc_settling_time_ms) ||
-	    (0U == config->encoder_settling_time_ms))
+	    (0U == config->adc_settling_time_ms))
 	{
 		result = false;
 	}
@@ -500,16 +498,17 @@ void encoder_read_task(void *pvParameters)
 			/* Select row */
 			keypad_cs_rows(true);
 			keypad_set_rows(r);
+			busy_wait_us_32(input_config.row_mux_settling_us);
 
 			/* Read channel A */
 			keypad_cs_columns(true);
 			keypad_set_columns(c);
-			vTaskDelay(pdMS_TO_TICKS(input_config.encoder_settling_time_ms));
+			busy_wait_us_32(input_config.col_mux_settling_us);
 			bool ch_a = !gpio_get(KEYPAD_ROW_INPUT); /* Active low pin */
 
 			/* Read channel B */
 			keypad_set_columns(c + 1U);
-			vTaskDelay(pdMS_TO_TICKS(input_config.encoder_settling_time_ms));
+			busy_wait_us_32(input_config.col_mux_settling_us);
 			bool ch_b = !gpio_get(KEYPAD_ROW_INPUT); /* Active low pin */
 
 			keypad_cs_columns(false);
@@ -536,11 +535,8 @@ void encoder_read_task(void *pvParameters)
 		task_prop->high_watermark = uxTaskGetStackHighWaterMark(NULL);
 		watchdog_update();
 
-		/* When no encoders are configured, avoid busy-looping */
-		if (0U == input_config.num_encoders)
-		{
-			vTaskDelay(pdMS_TO_TICKS(input_config.encoder_settling_time_ms));
-		}
+		/* Yield to other tasks; 1 tick ≈ 0.5 ms at 2 kHz gives ~2 kHz poll rate */
+		vTaskDelay(1);
 	}
 }
 

--- a/test/unit/test_inputs.c
+++ b/test/unit/test_inputs.c
@@ -184,6 +184,10 @@ static void test_gpio_mask_covers_all_mux_pins(void **state)
 /**
  * @brief Verify that MAX_NUM_ENCODERS can hold the maximum number of
  *        encoder pairs that can be derived from a full keypad row.
+ *
+ * With per-position encoder mapping, each encoder occupies one entry
+ * in the encoder_map array.  A full row of encoders still needs
+ * columns / 2 entries.
  */
 static void test_encoder_config_fits_keypad(void **state)
 {
@@ -197,6 +201,63 @@ static void test_encoder_config_fits_keypad(void **state)
     assert_true(MAX_NUM_ENCODERS >= max_encoders_per_row);
 }
 
+/**
+ * @brief Verify that encoder_skip is correctly built from the default config.
+ *
+ * The default config maps 4 encoders on row 7 at column pairs (0,1),
+ * (2,3), (4,5), (6,7).  All 8 positions on row 7 should be marked as
+ * encoder positions, and no other row should be affected.
+ */
+static void test_encoder_skip_built_from_default_config(void **state)
+{
+    (void)state;
+
+    assert_int_equal(INPUT_OK, input_init());
+
+    /* Row 7: all 8 columns should be marked as encoder positions */
+    for (uint8_t c = 0U; c < KEYPAD_COLUMNS; c++)
+    {
+        assert_true(input_is_encoder_position(7U, c));
+    }
+}
+
+/**
+ * @brief Verify that rows not hosting encoders are not marked in the skip lookup.
+ */
+static void test_encoder_non_encoder_positions_not_skipped(void **state)
+{
+    (void)state;
+
+    assert_int_equal(INPUT_OK, input_init());
+
+    /* Rows 0-6 should have no encoder positions with the default config */
+    for (uint8_t r = 0U; r < 7U; r++)
+    {
+        for (uint8_t c = 0U; c < KEYPAD_COLUMNS; c++)
+        {
+            assert_false(input_is_encoder_position(r, c));
+        }
+    }
+}
+
+/**
+ * @brief Verify the public getter matches direct expectations.
+ */
+static void test_input_is_encoder_position_getter(void **state)
+{
+    (void)state;
+
+    assert_int_equal(INPUT_OK, input_init());
+
+    /* Spot-check: (7,0) is encoder, (0,0) is not */
+    assert_true(input_is_encoder_position(7U, 0U));
+    assert_false(input_is_encoder_position(0U, 0U));
+
+    /* Spot-check: (7,3) is encoder (col 2 encoder uses 2,3), (6,3) is not */
+    assert_true(input_is_encoder_position(7U, 3U));
+    assert_false(input_is_encoder_position(6U, 3U));
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
@@ -206,6 +267,9 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_input_init_deletes_existing_queue, setup, teardown),
         cmocka_unit_test_setup_teardown(test_gpio_mask_covers_all_mux_pins, setup, teardown),
         cmocka_unit_test_setup_teardown(test_encoder_config_fits_keypad, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_encoder_skip_built_from_default_config, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_encoder_non_encoder_positions_not_skipped, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_input_is_encoder_position_getter, setup, teardown),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
Replace the row-level encoder_mask with a per-encoder mapping array
(encoder_map_t) that specifies exact (row, column) positions. This allows
encoders to be placed at arbitrary matrix positions while the remaining
keys on the same row continue to function normally.

Key changes:
- New encoder_map_t struct with row, col, and enabled fields
- encoder_skip[8][8] lookup built at init for fast keypad-task skipping
- Encoder task iterates configured mappings instead of scanning whole rows
- Validation rejects out-of-bounds and overlapping encoder positions
- Fixes out-of-bounds encoder_state[] access (old index was 28-31 for 8-element array)
- Fixes overlapping column pairs in quadrature sampling
- Adds input_is_encoder_position() getter and 3 new unit tests

https://claude.ai/code/session_019LnHcQfwQUZH5NycUjQ6wR