### PR TITLE
feat(encoders): add per-position rotary encoder mapping via keypad matrix

### DIFF
--- a/include/app_inputs.h
+++ b/include/app_inputs.h
@@ -128,7 +128,6 @@ typedef struct input_config_t
 	QueueHandle_t input_event_queue;          /**< Destination queue for generated events. */
 	encoder_map_t encoder_map[MAX_NUM_ENCODERS]; /**< Per-encoder position mappings. */
 	uint8_t num_encoders;                     /**< Number of configured encoder entries. */
-	uint16_t encoder_settling_time_ms;        /**< Delay between encoder samples. */
 	uint16_t col_mux_settling_us;             /**< 74HC138 column decoder propagation settling delay (µs). */
 	uint16_t row_mux_settling_us;             /**< 74HC4051 row MUX enable settling delay (µs). */
 } input_config_t;

--- a/src/app_inputs.c
+++ b/src/app_inputs.c
@@ -31,7 +31,6 @@ static input_config_t input_config = {
 	.key_settling_time_ms     = 10,
 	.adc_channels             = 16,
 	.adc_settling_time_ms     = 100,
-	.encoder_settling_time_ms = 10,
 	.num_encoders             = 4U,
 	.encoder_map              = {
 		{ .row = 7U, .col = 0U, .enabled = true },
@@ -89,8 +88,7 @@ static bool check_config_params(const input_config_t *config)
 	    (config->rows > KEYPAD_MAX_ROWS) ||
 	    (config->adc_channels > 16U) ||
 	    (0U == config->key_settling_time_ms) ||
-	    (0U == config->adc_settling_time_ms) ||
-	    (0U == config->encoder_settling_time_ms))
+	    (0U == config->adc_settling_time_ms))
 	{
 		result = false;
 	}
@@ -500,16 +498,17 @@ void encoder_read_task(void *pvParameters)
 			/* Select row */
 			keypad_cs_rows(true);
 			keypad_set_rows(r);
+			busy_wait_us_32(input_config.row_mux_settling_us);
 
 			/* Read channel A */
 			keypad_cs_columns(true);
 			keypad_set_columns(c);
-			vTaskDelay(pdMS_TO_TICKS(input_config.encoder_settling_time_ms));
+			busy_wait_us_32(input_config.col_mux_settling_us);
 			bool ch_a = !gpio_get(KEYPAD_ROW_INPUT); /* Active low pin */
 
 			/* Read channel B */
 			keypad_set_columns(c + 1U);
-			vTaskDelay(pdMS_TO_TICKS(input_config.encoder_settling_time_ms));
+			busy_wait_us_32(input_config.col_mux_settling_us);
 			bool ch_b = !gpio_get(KEYPAD_ROW_INPUT); /* Active low pin */
 
 			keypad_cs_columns(false);
@@ -536,11 +535,8 @@ void encoder_read_task(void *pvParameters)
 		task_prop->high_watermark = uxTaskGetStackHighWaterMark(NULL);
 		watchdog_update();
 
-		/* When no encoders are configured, avoid busy-looping */
-		if (0U == input_config.num_encoders)
-		{
-			vTaskDelay(pdMS_TO_TICKS(input_config.encoder_settling_time_ms));
-		}
+		/* Yield to other tasks; 1 tick ≈ 0.5 ms at 2 kHz gives ~2 kHz poll rate */
+		vTaskDelay(1);
 	}
 }
 


### PR DESCRIPTION
Replace the row-level encoder_mask with a per-encoder mapping array
(encoder_map_t) that specifies exact (row, column) positions. This allows
encoders to be placed at arbitrary matrix positions while the remaining
keys on the same row continue to function normally.

Key changes:
- New encoder_map_t struct with row, col, and enabled fields
- encoder_skip[8][8] lookup built at init for fast keypad-task skipping
- Encoder task iterates configured mappings instead of scanning whole rows
- Validation rejects out-of-bounds and overlapping encoder positions
- Fixes out-of-bounds encoder_state[] access (old index was 28-31 for 8-element array)
- Fixes overlapping column pairs in quadrature sampling
- Adds input_is_encoder_position() getter and 3 new unit tests

https://claude.ai/code/session_019LnHcQfwQUZH5NycUjQ6wR