### PR TITLE
docs: correct tick rate, build path, and statistics counter count

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ If containers are not available, install CMake, Doxygen, Python 3, the GNU Arm E
 
 ## Building
 - Initialize submodules before first build to pull the Pico SDK and FreeRTOS Kernel.
-- Create a `build` directory, configure with CMake from that directory, and build with Make. VS Code tasks named **Build Project** and **Clean Build** provide the same workflow.
-- The resulting UF2 image appears under `build/pi_controller.uf2`; copy it to the Pico while it is in BOOTSEL mode.
+- Configure and build with CMake presets: `cmake --preset pico-release && cmake --build --preset pico-release` (use `pico-debug` for debug builds). VS Code tasks named **Build Project** and **Clean Build** provide the same workflow.
+- The resulting UF2 image appears under `build-release/src/pi_controller.uf2` (or `build-debug/src/pi_controller.uf2` for the debug preset); copy it to the Pico while it is in BOOTSEL mode.
 
 ## ✨ Features and Architecture
 
 ### System layout
-- Raspberry Pi Pico running FreeRTOS SMP at a 1 kHz tick with dual-core scheduling.
+- Raspberry Pi Pico running FreeRTOS SMP at a 2 kHz tick with dual-core scheduling.
 - Nine tasks with explicit core affinity: USB CDC maintenance, CDC read/write, UART ingestion, packet decoding, outbound processing, status LED handling, keypad scanning, ADC sampling, and encoder tracking.
 - Queues sized per `include/app_config.h`: encoded reception queue (2048 bytes), CDC transmit queue (2048 packets), and data event queue (500 events).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -43,7 +43,7 @@ Three queues coordinate data movement and enforce isolation between producers an
 Queues provide thread-safe communication between tasks. Core affinity reduces contention, and each task contributes to watchdog updates to detect hangs. Communication queues use short waits or polling to keep USB paths responsive, while the event queue blocks until the host reads data to avoid dropping user input.
 
 ## Error Management and Diagnostics
-Fourteen counters track issues such as queue send or receive failures, watchdog timeouts, malformed messages, buffer overflows, and bytes transmitted or received. Critical errors persist in watchdog scratch registers, and the status LED communicates fault categories through distinct blink patterns so that resets can be diagnosed without host connectivity.
+Twenty-two counters track issues such as queue send or receive failures, watchdog timeouts, malformed messages, buffer overflows, bytes transmitted or received, and output/input driver errors. Critical errors persist in watchdog scratch registers, and the status LED communicates fault categories through distinct blink patterns so that resets can be diagnosed without host connectivity.
 
 ## Suggested Improvements
 Key recommendations for strengthening the architecture include:


### PR DESCRIPTION
Align README and ARCHITECTURE with the current firmware: FreeRTOS tick
is 2 kHz (configTICK_RATE_HZ), the UF2 image ships under
build-release/src/ via the CMake presets, and error_management.h now
defines 22 statistics counters.