### PR TITLE
perf(comm): switch uart_event_task to event-driven RX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,11 @@ if(NOT HOST_BUILD)
     set(FAMILY rp2040)
     set(BOARD pico_sdk)
 
+    # Drive TinyUSB off the FreeRTOS OSAL so tud_task_ext() actually blocks
+    # on its event queue instead of polling.  Must be set before the Pico SDK
+    # (and hence tinyusb's family.cmake) is loaded.
+    set(TINYUSB_OPT_OS OPT_OS_FREERTOS)
+
     # Pull in SDK (must be before project)
     set(PICO_SDK_PATH "${CMAKE_CURRENT_SOURCE_DIR}/lib/pico-sdk/")
     include(lib/pico-sdk/pico_sdk_init.cmake)

--- a/docs/mainpage.dox
+++ b/docs/mainpage.dox
@@ -44,7 +44,7 @@
  * | Task | Responsibility |
  * | ---- | -------------- |
  * | `cdc_task` | Services TinyUSB and pumps the device stack. |
- * | `uart_event_task` | Reads CDC bytes in bulk and assembles complete COBS frames via @ref encoded_framer.h. |
+ * | `uart_event_task` | Event-driven task woken by the TinyUSB RX callback; drains the CDC FIFO and assembles complete COBS frames via @ref encoded_framer.h. |
  * | `decode_reception_task` | Dequeues assembled frames, decodes them and hands them to @ref app_comm_process_inbound(). |
  * | `process_outbound_task` | Converts queued @ref data_events_t into CDC packets. |
  * | `cdc_write_task` | Streams encoded frames to the host while honouring flow control. |

--- a/include/app_config.h
+++ b/include/app_config.h
@@ -90,6 +90,17 @@
 #define UART_EVENT_TASK_WAIT_MS 1000U
 
 /**
+ * @brief Safety timeout used by @ref cdc_task while blocked on the TinyUSB
+ *        event queue (milliseconds).
+ *
+ * With @c CFG_TUSB_OS=OPT_OS_FREERTOS, @c tud_task_ext() sleeps on a kernel
+ * queue and is woken by the USB IRQ.  The bounded wait ensures the task
+ * still pets the watchdog and refreshes its stack watermark when no USB
+ * activity is happening.
+ */
+#define CDC_TASK_SAFETY_TIMEOUT_MS 1000U
+
+/**
  * @brief Marker indicating the end of a COBS packet.
  */
 #define PACKET_MARKER (uint8_t)0x00
@@ -137,7 +148,7 @@
  */
 #define CDC_TASK_CORE_AFFINITY              CORE_0_AFFINITY
 #define UART_EVENT_TASK_CORE_AFFINITY       CORE_0_AFFINITY
-#define LED_STATUS_TASK_CORE_AFFINITY       CORE_0_AFFINITY
+#define LED_STATUS_TASK_CORE_AFFINITY       CORE_1_AFFINITY
 #define DECODE_RECEPTION_TASK_CORE_AFFINITY CORE_1_AFFINITY
 #define PROCESS_OUTBOUND_TASK_CORE_AFFINITY CORE_1_AFFINITY
 #define ADC_READ_TASK_CORE_AFFINITY         CORE_1_AFFINITY

--- a/include/app_config.h
+++ b/include/app_config.h
@@ -79,6 +79,17 @@
 #define QUEUE_RETRY_DELAY_MS 1U
 
 /**
+ * @brief Safety timeout used by @ref uart_event_task while blocked on a
+ *        TinyUSB RX notification (milliseconds).
+ *
+ * The TinyUSB @c tud_cdc_rx_cb callback wakes the task as soon as bytes are
+ * available.  This timeout provides a fallback so the task still services
+ * the FIFO, updates its stack watermark and feeds the watchdog even if a
+ * notification is ever missed.
+ */
+#define UART_EVENT_TASK_WAIT_MS 1000U
+
+/**
  * @brief Marker indicating the end of a COBS packet.
  */
 #define PACKET_MARKER (uint8_t)0x00

--- a/src/app_comm.c
+++ b/src/app_comm.c
@@ -34,6 +34,33 @@ void tud_cdc_line_state_cb(uint8_t itf, bool dtr, bool rts)
 }
 
 /**
+ * @brief Callback invoked by the TinyUSB device stack when new CDC bytes are
+ *        available in the RX FIFO.
+ *
+ * Runs in the context of @c tud_task (i.e. @ref cdc_task), not in an ISR, so
+ * the plain task notification API is used to wake @ref uart_event_task.  The
+ * handle is resolved via the application context; if the consumer task has
+ * not been created yet the notification is simply skipped and the safety
+ * timeout inside @ref uart_event_task's wait will still drain whatever is in
+ * the FIFO.
+ *
+ * @param[in] itf Interface number (only interface 0 is serviced).
+ */
+void tud_cdc_rx_cb(uint8_t itf)
+{
+	if (0U != itf)
+	{
+		return;
+	}
+
+	const task_props_t *const props = app_context_task_props(UART_EVENT_TASK);
+	if ((NULL != props) && (NULL != props->task_handle))
+	{
+		(void)xTaskNotifyGive(props->task_handle);
+	}
+}
+
+/**
  * @brief Calculates the XOR checksum.
  *
  * @param[in] data   Pointer to the data.

--- a/src/app_tasks.c
+++ b/src/app_tasks.c
@@ -377,7 +377,13 @@ static void uart_event_task(void *pvParameters)
 }
 
 /**
- * @brief TinyUSB device task responsible for polling the USB stack.
+ * @brief TinyUSB device task responsible for servicing the USB stack.
+ *
+ * With CFG_TUSB_OS=OPT_OS_FREERTOS, tud_task_ext() blocks on the TinyUSB
+ * event queue until an IRQ posts work, so this task consumes no CPU while
+ * the bus is idle.  A bounded timeout is used instead of WAIT_FOREVER so
+ * the task still wakes periodically to pet the watchdog and refresh the
+ * stack watermark when the link is quiet.
  *
  * @param[in,out] pvParameters Pointer to the owning task properties structure.
  */
@@ -386,10 +392,9 @@ static void cdc_task(void *pvParameters)
 	task_props_t *task_prop = (task_props_t *)pvParameters;
 	for (;;)
 	{
-		tud_task();
+		tud_task_ext(CDC_TASK_SAFETY_TIMEOUT_MS, false);
 		task_prop->high_watermark = uxTaskGetStackHighWaterMark(NULL);
 		watchdog_update();
-		taskYIELD();
 	}
 }
 

--- a/src/app_tasks.c
+++ b/src/app_tasks.c
@@ -300,10 +300,19 @@ static void cleanup_comm_subsystem(void)
  * @brief Task that reads raw CDC bytes, assembles complete COBS frames and
  *        enqueues them for decoding.
  *
- * Bytes are read in bulk from the TinyUSB endpoint into a local buffer and
- * fed into an @ref encoded_framer_t state machine.  Only complete frames are
- * pushed to the encoded queue, which drastically reduces per-byte queue
- * overhead compared to the previous byte-level approach.
+ * The task is event-driven: the TinyUSB CDC RX callback
+ * (@c tud_cdc_rx_cb in @ref app_comm.c) issues a task notification whenever
+ * new bytes are pushed into the RX FIFO, waking this task.  Between
+ * notifications the task blocks on @c ulTaskNotifyTake and does not burn
+ * CPU.  A safety timeout of @ref UART_EVENT_TASK_WAIT_MS is used so that the
+ * task still periodically services the FIFO and refreshes the watchdog even
+ * if a notification is missed (for example during startup, before the host
+ * is connected, or if the callback fires before the task handle is
+ * registered in the application context).
+ *
+ * Each wake-up drains the FIFO to empty in bulk chunks of
+ * @ref CDC_READ_CHUNK_SIZE bytes, feeding bytes into an @ref encoded_framer_t
+ * state machine.  Only complete frames are pushed to the encoded queue.
  *
  * @param[in,out] pvParameters Pointer to the owning task properties structure.
  */
@@ -321,39 +330,49 @@ static void uart_event_task(void *pvParameters)
 		task_prop->high_watermark = uxTaskGetStackHighWaterMark(NULL);
 		watchdog_update();
 
-		if (!tud_cdc_n_available(0))
-		{
-			taskYIELD();
-			continue;
-		}
-
-		const uint32_t count = tud_cdc_n_read(0, receive_buffer, sizeof(receive_buffer));
-		statistics_add_to_counter(BYTES_RECEIVED, count);
-
 		QueueHandle_t queue = app_context_get_encoded_queue();
 
-		for (uint32_t i = 0U; i < count; i++)
+		/* Drain the CDC RX FIFO completely before going back to sleep.
+		 * tud_cdc_n_read() returns 0 when the FIFO is empty, which
+		 * terminates the inner loop; further bytes will trigger
+		 * tud_cdc_rx_cb and wake the task again. */
+		for (;;)
 		{
-			const framer_result_t result = encoded_framer_push_byte(&framer, receive_buffer[i], &frame);
-			switch (result)
+			const uint32_t count = tud_cdc_n_read(0, receive_buffer, sizeof(receive_buffer));
+			if (0U == count)
 			{
-			case FRAMER_FRAME_READY:
-				if ((NULL == queue) || (xQueueSend(queue, &frame, pdMS_TO_TICKS(QUEUE_RETRY_DELAY_MS)) != pdTRUE))
-				{
-					statistics_increment_counter(QUEUE_SEND_ERROR);
-				}
-				break;
-			case FRAMER_EMPTY_FRAME:
-				statistics_increment_counter(COBS_DECODE_ERROR);
-				break;
-			case FRAMER_OVERFLOW:
-				statistics_increment_counter(RECEIVE_BUFFER_OVERFLOW_ERROR);
-				break;
-			case FRAMER_NEED_MORE_DATA:
-			default:
 				break;
 			}
+			statistics_add_to_counter(BYTES_RECEIVED, count);
+
+			for (uint32_t i = 0U; i < count; i++)
+			{
+				const framer_result_t result = encoded_framer_push_byte(&framer, receive_buffer[i], &frame);
+				switch (result)
+				{
+				case FRAMER_FRAME_READY:
+					if ((NULL == queue) || (xQueueSend(queue, &frame, pdMS_TO_TICKS(QUEUE_RETRY_DELAY_MS)) != pdTRUE))
+					{
+						statistics_increment_counter(QUEUE_SEND_ERROR);
+					}
+					break;
+				case FRAMER_EMPTY_FRAME:
+					statistics_increment_counter(COBS_DECODE_ERROR);
+					break;
+				case FRAMER_OVERFLOW:
+					statistics_increment_counter(RECEIVE_BUFFER_OVERFLOW_ERROR);
+					break;
+				case FRAMER_NEED_MORE_DATA:
+				default:
+					break;
+				}
+			}
 		}
+
+		/* Block until tud_cdc_rx_cb notifies us or the safety timeout
+		 * elapses.  Timeout keeps the task alive for watchdog /
+		 * watermark updates even when the host is idle. */
+		(void)ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(UART_EVENT_TASK_WAIT_MS));
 	}
 }
 


### PR DESCRIPTION
## Summary

Makes the entire inbound USB path event-driven. `uart_event_task` used to poll `tud_cdc_n_available` + `taskYIELD`, and `cdc_task` used to poll `tud_task()` + `taskYIELD` — together keeping core 0 pinned at ~49% CPU regardless of load. Both tasks now sleep until there is real work to do.

## Changes

### `src/app_comm.c` — new `tud_cdc_rx_cb`
TinyUSB calls this hook from `tud_task` context (inside `cdc_task`) whenever RX bytes arrive in the CDC FIFO. The callback resolves the `uart_event_task` handle via `app_context_task_props` and issues `xTaskNotifyGive`. Filters on interface 0 and no-ops if the task handle is not yet available.

### `src/app_tasks.c` — `uart_event_task` becomes event-driven
- Removed the `if (!tud_cdc_n_available(0)) taskYIELD(); continue;` polling loop.
- On every wake-up the task drains the RX FIFO to empty in `CDC_READ_CHUNK_SIZE` bulk reads, feeds bytes into the framer, and pushes complete frames to the encoded queue.
- After draining, blocks on `ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(UART_EVENT_TASK_WAIT_MS))`. The 1 s safety timeout keeps the watermark / watchdog refreshed and recovers from any lost notification (e.g. callback firing before the task handle is registered).

### `src/app_tasks.c` — `cdc_task` switches to blocking `tud_task_ext()`
- Replaced `tud_task()` + `taskYIELD()` with `tud_task_ext(CDC_TASK_SAFETY_TIMEOUT_MS, false)`.
- With `CFG_TUSB_OS=OPT_OS_FREERTOS`, `tud_task_ext()` sleeps on the TinyUSB kernel queue and is woken by the USB IRQ — zero CPU burn when the bus is idle.
- The bounded 1 s timeout ensures the watchdog is petted and the stack watermark is refreshed even during link-quiet periods.

### `CMakeLists.txt`
- Added `set(TINYUSB_OPT_OS OPT_OS_FREERTOS)` before the Pico SDK is loaded, enabling the FreeRTOS OSAL inside TinyUSB so `tud_task_ext()` actually blocks.

### `include/app_config.h`
- New `UART_EVENT_TASK_WAIT_MS = 1000U` — safety timeout for `uart_event_task`.
- New `CDC_TASK_SAFETY_TIMEOUT_MS = 1000U` — safety timeout for `cdc_task`.
- `LED_STATUS_TASK_CORE_AFFINITY` moved from core 0 to core 1 to free core 0 for the USB stack.

### `docs/mainpage.dox`
- Task table updated to describe the new event-driven behaviour for both tasks.

## Expected impact

Before this change, baud-sweep telemetry showed `cdc_task` and `uart_event_task` each consuming ~49% of core 0. After this change:

- **Idle / light load:** both tasks sleep; core 0 cycles go to the FreeRTOS idle task.
- **Sustained load:** `cdc_task` wakes on each USB IRQ, drains the TinyUSB stack, then sleeps; `uart_event_task` wakes on each `tud_cdc_rx_cb` notification, drains all available bytes in one shot, pushes frames, sleeps. One notification typically amortizes many frames.
- **Throughput ceiling:** moves from ~3000 msg/s sustained (bounded by the cooperative polling share) upwards — exact figure should be validated with a baud sweep.

## Test plan

- [x] Host tests pass: `test_encoded_framer`, `test_cobs`, `test_cobs_standalone`, `test_error_management`.
- [x] `cmake --build --preset pico-release` succeeds; `pi_controller.uf2` generated cleanly (no warnings on touched files).
- [ ] Re-run baud sweep on hardware and compare throughput / CPU share of `cdc_task` and `uart_event_task` with the post-#92 baseline.
- [ ] CI (cppcheck + MISRA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)