### PR TITLE
perf(adc): µs-resolution settling, oversampling and hysteresis

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,24 @@ For protocol framing, payload layouts, and pre-COBS example frames, see `docs/CO
 - Static analysis relies on cppcheck with the MISRA addon, SonarLint, and Flawfinder. Helper scripts under `scripts/` wrap common checks.
 - Doxygen configuration lives in `docs/Doxyfile`, and generated HTML output is written to `docs/html/`.
 
-## Additional Documentation
-- System architecture overview: `docs/ARCHITECTURE.md`.
-- Output subsystem details: `docs/OUTPUT.md`.
-- Cppcheck and MISRA workflow: `docs/CPPCHECK_SETUP.md`.
-- Documentation update guidance: `docs/PROMPT.md`.
+## Documentation
+
+Start with the [docs index](docs/README.md) for the full map. Quick links:
+
+**Architecture & Protocol**
+- [System architecture](docs/ARCHITECTURE.md) — tasks, queues, data flows, core affinity.
+- [USB CDC command protocol](docs/COMMANDS.md) — COBS framing, command IDs, payload layouts, example frames.
+- [Output subsystem](docs/OUTPUT.md) — SPI fabric, TM1639/TM1637 drivers, buffering.
+
+**Tooling & Quality**
+- [Cppcheck + MISRA setup](docs/CPPCHECK_SETUP.md) — static analysis workflow.
+- [DevContainer details](.devcontainer/README.md) — toolchain, extensions, tasks.
+- [Unit test framework](test/README.md) — CMocka, mocks, coverage.
+
+**Contributor reference**
+- [`CLAUDE.md`](CLAUDE.md) — single source of truth for build commands, code style, and operational boundaries.
+- [README enhancement guidance](docs/PROMPT.md) — how to keep this README in sync with the codebase.
+- [Agent persona](docs/AGENTS.md) — context for AI assistants working in the repo.
 
 ## Troubleshooting
 - If builds fail, confirm submodules are initialized and the Arm toolchain is available. Recreate the DevContainer if dependencies are missing.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -7,3 +7,7 @@
 ## Agent Persona
 
 Senior Embedded Systems & Real-Time Firmware Architect (RP2040, FreeRTOS SMP, C/C++).
+
+---
+
+**See also:** [Docs index](README.md) · [`../CLAUDE.md`](../CLAUDE.md)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -60,3 +60,7 @@ Key recommendations for strengthening the architecture include:
 
 ## Conclusion
 The current architecture cleanly separates responsibilities across FreeRTOS tasks and cores, leveraging queues for safe communication. The improvement areas above focus on latency reduction, robustness, and observability so the firmware can scale to heavier workloads while maintaining predictable behavior.
+
+---
+
+**See also:** [Docs index](README.md) · [OUTPUT](OUTPUT.md) · [COMMANDS](COMMANDS.md)

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -228,3 +228,7 @@ The examples assume `BOARD_ID = 0x01`. Commands that use a controller ID use
 > byte appears as the first payload byte (`0x20` or `0x21` for controller ID 1),
 > with the controller ID stored in the upper 3 bits and the display command in
 > the lower 5 bits.
+
+---
+
+**See also:** [Docs index](README.md) · [ARCHITECTURE](ARCHITECTURE.md) · [OUTPUT](OUTPUT.md)

--- a/docs/CPPCHECK_SETUP.md
+++ b/docs/CPPCHECK_SETUP.md
@@ -43,3 +43,7 @@ Static analysis can run in continuous integration by invoking the full cppcheck 
 
 ## Expected Results
 A healthy run should load MISRA rules correctly, avoid critical preprocessor errors, and limit warnings to actionable findings in the project code while suppressing noise from external dependencies.
+
+---
+
+**See also:** [Docs index](README.md) · [`../CLAUDE.md`](../CLAUDE.md)

--- a/docs/OUTPUT.md
+++ b/docs/OUTPUT.md
@@ -45,3 +45,7 @@ New driver types can be added by extending the driver initialization and handler
 - Raspberry Pi Pico SDK Documentation
 - TM1639 Datasheet
 - FreeRTOS Documentation
+
+---
+
+**See also:** [Docs index](README.md) · [ARCHITECTURE](ARCHITECTURE.md) · [COMMANDS](COMMANDS.md)

--- a/docs/PROMPT.md
+++ b/docs/PROMPT.md
@@ -35,3 +35,7 @@ Prioritize container-based workflows when available. If a `.devcontainer` direct
 - Legacy or obsolete references have been removed.
 - Onboarding steps are clear, starting with the simplest option.
 - Sections are concise, accurate, and free from code snippets to keep the documentation focused on behavior and usage.
+
+---
+
+**See also:** [Docs index](README.md) · [`../README.md`](../README.md) · [`../CLAUDE.md`](../CLAUDE.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,22 @@
+# Documentation Index
+
+Technical documentation for the Signalbridge controller firmware. For build/test
+commands and contribution rules, see [`../CLAUDE.md`](../CLAUDE.md). For the
+project overview, see [`../README.md`](../README.md).
+
+## Architecture & Protocol
+- [ARCHITECTURE.md](ARCHITECTURE.md) — FreeRTOS SMP task layout, queues, data flows, error management.
+- [COMMANDS.md](COMMANDS.md) — USB CDC command protocol: COBS framing, command IDs, payload formats, example frames.
+- [OUTPUT.md](OUTPUT.md) — output/display subsystem: SPI fabric, TM1639/TM1637 drivers, buffering, concurrency.
+
+## Tooling
+- [CPPCHECK_SETUP.md](CPPCHECK_SETUP.md) — Cppcheck + MISRA C:2012 configuration and workflow.
+
+## Meta
+- [PROMPT.md](PROMPT.md) — guidance for keeping the root README synchronized with the codebase.
+- [AGENTS.md](AGENTS.md) — agent persona; defers to [`../CLAUDE.md`](../CLAUDE.md).
+
+## Generated API reference
+`Doxyfile` and `mainpage.dox` produce HTML output under `docs/html/` when the
+Doxygen target is built. See the **Code Quality and Documentation** section
+of the [root README](../README.md) for details.


### PR DESCRIPTION
Replace the 100 ms vTaskDelay between ADC channel selections with a
configurable µs-scale busy-wait (default 500 µs) and add per-channel
oversampling plus a symmetric hysteresis deadband.  With the legacy
defaults the full 16-channel scan took ~1.6 s (~0.6 Hz per channel),
which is far too slow for analog axes such as throttle or sidestick.

The new defaults:
- adc_settling_us = 500 (74HC4067 + ~10 kΩ pot has a real settling
  time on the order of tens of µs; 500 µs keeps a healthy margin)
- adc_oversample = 4 raw samples averaged per scan to suppress LSB
  noise without adding noticeable latency
- adc_hysteresis = 8 LSB deadband (~0.2 % of full scale) to stop the
  USB packet flood that pure change-detection would produce at the
  new sampling rate
- adc_scan_interval_ms = 1 cooperative yield between full scans so
  the keypad task at the same priority is not starved
- ADC_NUM_TAPS bumped from 4 to 8 for stronger noise rejection on the
  filtered output

For 4 active axes (typical throttle + sidestick setup) this brings
per-axis refresh from ~0.6 Hz to ~250 Hz while keeping 12-bit
resolution.  Lower adc_channels to scan only the axes in use.

Expose adc_should_emit() so the hysteresis decision is unit-testable
and add CMocka coverage for the new behaviour and config defaults.

https://claude.ai/code/session_016fCxX6QosMyVtHsEvDH4Fk