### PR TITLE
perf(tm1639): batch address+data flush into a single SPI burst

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ assets/        — Logos and diagrams
 - **Core 0**: USB CDC tasks (read/write/maintenance), status LED
 - **Core 1**: Input scanning (keypad, ADC, encoders), output driving (SPI/TM1639/TM1637/PWM), COBS decode
 - **Communication**: COBS framing with 0x00 delimiter. 3-byte header + 20-byte payload + checksum
-- **SPI bus**: 500 kHz, mutex-protected, with multiplexer routing for multiple display drivers
+- **SPI bus**: 1 MHz, mutex-protected, with multiplexer routing for multiple display drivers
 - **Error handling**: Watchdog (5s timeout), scratch registers persist error info across resets, status LED blink patterns, 22 statistics counters
 - **Memory constraints**: 2MB Flash, 264KB RAM, 128KB FreeRTOS heap, stack-usage warnings at 3.5KB
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ For protocol framing, payload layouts, and pre-COBS example frames, see `docs/CO
 ## Hardware Platform
 - Target: Raspberry Pi Pico (RP2040) with Pico SDK 2.1.1 or newer and the current FreeRTOS Kernel.
 - Output SPI clock uses the Pico default pins 18 (SCK) and 19 (TX). Input multiplexers and PWM run on the GPIO assignments listed above.
-- The watchdog enforces a five-second timeout, and the SPI bus operates at 500 kHz for TM1639 reliability.
+- The watchdog enforces a five-second timeout, and the SPI bus operates at 1 MHz (the TM1639 datasheet maximum).
 
 ## Code Quality and Documentation
 - MISRA C:2012 guidance informs implementation choices; suppressions are documented for external dependencies and hardware access.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,22 +31,22 @@ Three queues coordinate data movement and enforce isolation between producers an
 
 | Queue | Producer | Consumer | Size | Purpose |
 | :--- | :--- | :--- | :--- | :--- |
-| Encoded reception queue | UART event task | Decode reception task | 2048 bytes | Buffers COBS-encoded bytes arriving from the host. |
+| Encoded reception queue | UART event task | Decode reception task | 256 frames | Buffers complete COBS-encoded frames arriving from the host. |
 | Data event queue | Keypad, ADC, encoder tasks | Process outbound task | 500 events | Stores multiplexed input events until the host fetches them. |
-| CDC transmit queue | Process outbound task and decoding path | CDC write task | 2048 packets | Holds formatted packets until the USB interface is ready. |
+| CDC transmit queue | Process outbound task and decoding path | CDC write task | 256 packets | Holds formatted packets until the USB interface is ready (~7 KB of FreeRTOS heap; ~1.7× the TinyUSB TX FIFO). |
 
 ## Data Flows
 - **Host to device:** The UART event task captures bytes from the host, the decode task reconstructs and validates packets, and the processing logic triggers hardware actions or prepares responses.
 - **Device to host:** Hardware tasks enqueue events, the outbound processor formats them, and the CDC write task transmits packets to the host. The queue architecture ensures communication duties on Core 0 remain responsive even when Core 1 is busy.
 
 ## Synchronization and Protection
-Queues provide thread-safe communication between tasks. Core affinity reduces contention, and each task contributes to watchdog updates to detect hangs. Communication queues use short waits or polling to keep USB paths responsive, while the event queue blocks until the host reads data to avoid dropping user input.
+Queues provide thread-safe communication between tasks. Core affinity reduces contention, and each task contributes to watchdog updates to detect hangs. Communication queues use short waits or polling to keep USB paths responsive. Input-event enqueues wait up to `INPUT_QUEUE_SEND_TIMEOUT_MS` (100 ms) when the data event queue is full, then drop the event and increment a statistics counter — bounding how long a stalled host can freeze the keypad/encoder scan.
 
 ## Error Management and Diagnostics
 Twenty-two counters track issues such as queue send or receive failures, watchdog timeouts, malformed messages, buffer overflows, bytes transmitted or received, and output/input driver errors. Critical errors persist in watchdog scratch registers, and the status LED communicates fault categories through distinct blink patterns so that resets can be diagnosed without host connectivity.
 
 ## Suggested Improvements
-Key recommendations for strengthening the architecture include:
+A prioritized performance analysis — including which of these items have already been implemented and which remain proposed — is maintained in [PERFORMANCE.md](PERFORMANCE.md). Key recommendations for strengthening the architecture include:
 - Introduce differentiated task priorities so USB communication outranks lower-urgency processing.
 - Expand the data event queue capacity to reduce blocking during bursts of hardware activity.
 - Favor interrupt-driven input capture for the keypad, ADC, and encoder paths to reduce latency and CPU usage.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -30,7 +30,7 @@ plan](#follow-up-measurement-plan) before undertaking the larger restructures.
 | 4 | SPI 500 kHz → 1 MHz | Displays | Medium (halves TM1639 bus time & mutex hold) | Low–Med (HW signal integrity) | S | **Implemented** | `include/app_outputs.h` `SPI_FREQUENCY` |
 | 5 | TM1637 bit delay 3 → 2 µs | Displays | Medium (~33% faster bit-banged writes under SPI mutex) | Low–Med (HW) | S | **Implemented** | `src/tm1637.c` `TM1637_DELAY_US` (`#ifndef`-overridable) |
 | 6 | CDC write loop: yield only on FIFO-full, coalesce flushes, disconnect bail-out | USB TX | Medium (no busy-yield per chunk; fewer small USB transfers; no watchdog reset on mid-packet disconnect) | Low | M | **Implemented** | `src/app_tasks.c` `cdc_write_task` |
-| 7 | Disable unused run-time stats / trace / stats formatting | Scheduler | Medium (timer read on every context switch removed) | Low | S | **Implemented** | `include/FreeRTOSConfig.h` |
+| 7 | ~~Disable run-time stats / trace / stats formatting~~ | Scheduler | — | — | S | **Rejected** — consumed by `PC_TASK_STATUS_CMD` | `include/FreeRTOSConfig.h` |
 | 8 | Disable empty tick hook | Scheduler | Low–Med (2000 empty calls/s/core removed) | Low | S | **Implemented** | `include/FreeRTOSConfig.h`, `src/hooks.c` |
 | 9 | Rate-limit `uxTaskGetStackHighWaterMark` to every 64th loop pass | Scheduler | Low–Med (multi-MB/s of diagnostic stack scans removed) | Low | S | **Implemented** | `src/app_tasks.c`, `src/app_inputs.c` |
 | 10 | Input-event enqueue timeout 1000 → 100 ms | Inputs | Low–Med (bounds worst-case keypad stall 10×) | Low | S | **Implemented** | `include/app_config.h` `INPUT_QUEUE_SEND_TIMEOUT_MS` |
@@ -60,7 +60,6 @@ Each change keeps a single revert knob and documents it at the definition site.
 | `CDC_TRANSMIT_QUEUE_SIZE` (`include/app_config.h`) | `256U` | `2048U` |
 | `INPUT_QUEUE_SEND_TIMEOUT_MS` (`include/app_config.h`) | `100U` | `1000U` |
 | `TM1637_DELAY_US` (`src/tm1637.c`) | `2` (build-overridable) | `3` |
-| `configGENERATE_RUN_TIME_STATS` etc. (`include/FreeRTOSConfig.h`) | `0` | `1` |
 | `configUSE_TICK_HOOK` (`include/FreeRTOSConfig.h`) | `0` | `1` |
 
 Notes per item:
@@ -93,13 +92,19 @@ Notes per item:
    flush still happens as soon as the queue empties), and abandons the packet
    if the host drops the link mid-write instead of spinning until the watchdog
    fires.
-7-9. **Scheduler trims (items 7–9).** Run-time stats added a timer read to
-   every context switch with no consumer; the tick hook was an empty call at
-   2000 Hz per core; the watermark refresh full-stack scan ran every loop pass
-   in every task (~2.5 MB/s from the keypad task alone) and is now sampled
-   every 64th pass. To profile task CPU usage, temporarily re-enable
-   `configGENERATE_RUN_TIME_STATS` with `portGET_RUN_TIME_COUNTER_VALUE()`
-   mapped to `time_us_32()`.
+7. **Run-time stats (item 7) — rejected.** Initially disabled on the
+   assumption nothing consumed them, but the `PC_TASK_STATUS_CMD` handler
+   (`send_heap_status` in `src/app_comm.c`) reports per-task and idle CPU
+   usage to the host via `ulTaskGetRunTimeCounter/Percent` and
+   `ulTaskGetIdleRunTimeCounter/Percent`, all of which require
+   `configGENERATE_RUN_TIME_STATS=1`. `configGENERATE_RUN_TIME_STATS`,
+   `configUSE_TRACE_FACILITY` and `configUSE_STATS_FORMATTING_FUNCTIONS`
+   are therefore left enabled. The per-context-switch timer read is the cost
+   of a shipped diagnostic feature, not dead weight.
+8-9. **Scheduler trims (items 8–9).** The tick hook was an empty call at
+   2000 Hz per core (now disabled); the watermark refresh full-stack scan ran
+   every loop pass in every task (~2.5 MB/s from the keypad task alone) and is
+   now sampled every 64th pass.
 10. **Input enqueue timeout (item 10).** A full data-event queue already ended
    in drop-and-count after blocking the scan for 1 s; the shorter bound only
    limits the input outage while the 500-slot queue provides the real burst
@@ -137,9 +142,9 @@ Notes per item:
 
 Before investing in items 12–14, profile on hardware:
 
-1. Re-enable `configGENERATE_RUN_TIME_STATS` on a debug build (map the counter
-   to `time_us_32()`), dump per-task CPU via a debug command, and confirm the
-   ADC/keypad/idle split on Core 1.
+1. Query per-task and idle CPU usage over `PC_TASK_STATUS_CMD` (already backed
+   by the enabled run-time stats) and confirm the ADC/keypad/idle split on
+   Core 1.
 2. Toggle a spare GPIO around the ADC scan and display flush paths and measure
    with a logic analyzer to validate the computed timings in this document.
 3. Use the existing statistics counters (`INPUT_QUEUE_FULL_ERROR`,

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,151 @@
+# Performance Analysis & Improvement Plan
+
+**Scope & method:** static analysis of task timing, queue/heap budgets, and driver
+transaction costs across the firmware (July 2026). Figures are computed from the
+code and datasheets, not profiled on hardware — see [Follow-up measurement
+plan](#follow-up-measurement-plan) before undertaking the larger restructures.
+
+## System budget snapshot
+
+- **CPU:** RP2040, 2× Cortex-M0+ (no HW divide), 200 MHz via
+  `PICO_USE_FASTEST_SUPPORTED_CLOCK=1` on SDK ≥ 2.x. All code runs from
+  flash (XIP); no RAM-resident functions.
+- **RTOS:** FreeRTOS SMP, tick 2000 Hz (0.5 ms), preemption + time slicing,
+  no tickless idle. 128 KB heap (heap_4).
+- **Task layout:** Core 0 — CDC (prio 3), CDC write (2), UART event (2);
+  Core 1 — decode (2), outbound (1), ADC (1), keypad (1), LED status (1).
+  Four equal-priority tasks round-robin on Core 1, so any busy-wait there
+  starves the others.
+- **Comm path:** COBS frames ≤ 26 bytes; TinyUSB CDC with 4 KB RX/TX FIFOs;
+  TinyUSB runs on the FreeRTOS OSAL (`TINYUSB_OPT_OS=OPT_OS_FREERTOS`
+  injected by the top-level CMakeLists).
+
+## Prioritized opportunities
+
+| # | Item | Area | Impact | Risk | Effort | Status | Where |
+|---|------|------|--------|------|--------|--------|-------|
+| 1 | ADC settling busy-wait 500 → 100 µs | Inputs / Core 1 | **High** (~8 ms → ~1.6 ms CPU spin per scan) | Low (revert knob) | S | **Implemented** | `include/app_inputs.h` `ADC_DEFAULT_SETTLING_US` |
+| 2 | CDC TX queue 2048 → 256 slots | Memory | **High** (frees ~48 KB of 128 KB heap) | Low | S | **Implemented** | `include/app_config.h` `CDC_TRANSMIT_QUEUE_SIZE` |
+| 3 | TM1639 flush batched into one 17-byte SPI burst | Displays | Medium (removes 16 per-call overheads per flush) | Low (same byte stream, unit-tested) | S | **Implemented** | `src/tm1639.c` `tm1639_flush` |
+| 4 | SPI 500 kHz → 1 MHz | Displays | Medium (halves TM1639 bus time & mutex hold) | Low–Med (HW signal integrity) | S | **Implemented** | `include/app_outputs.h` `SPI_FREQUENCY` |
+| 5 | TM1637 bit delay 3 → 2 µs | Displays | Medium (~33% faster bit-banged writes under SPI mutex) | Low–Med (HW) | S | **Implemented** | `src/tm1637.c` `TM1637_DELAY_US` (`#ifndef`-overridable) |
+| 6 | CDC write loop: yield only on FIFO-full, coalesce flushes, disconnect bail-out | USB TX | Medium (no busy-yield per chunk; fewer small USB transfers; no watchdog reset on mid-packet disconnect) | Low | M | **Implemented** | `src/app_tasks.c` `cdc_write_task` |
+| 7 | Disable unused run-time stats / trace / stats formatting | Scheduler | Medium (timer read on every context switch removed) | Low | S | **Implemented** | `include/FreeRTOSConfig.h` |
+| 8 | Disable empty tick hook | Scheduler | Low–Med (2000 empty calls/s/core removed) | Low | S | **Implemented** | `include/FreeRTOSConfig.h`, `src/hooks.c` |
+| 9 | Rate-limit `uxTaskGetStackHighWaterMark` to every 64th loop pass | Scheduler | Low–Med (multi-MB/s of diagnostic stack scans removed) | Low | S | **Implemented** | `src/app_tasks.c`, `src/app_inputs.c` |
+| 10 | Input-event enqueue timeout 1000 → 100 ms | Inputs | Low–Med (bounds worst-case keypad stall 10×) | Low | S | **Implemented** | `include/app_config.h` `INPUT_QUEUE_SEND_TIMEOUT_MS` |
+| 11 | Remove inert `PICO_HEAP_SZIE` typo define; dedupe FreeRTOSConfig defines | Build hygiene | None (provable no-ops) | None | S | **Implemented** | `src/CMakeLists.txt`, `include/FreeRTOSConfig.h` |
+| 12 | ADC: timer/DMA-driven scan instead of task busy-wait | Inputs | **High** (removes remaining ~1.6 ms/scan spin entirely) | Med–High | L | Proposed | `src/app_inputs.c` |
+| 13 | Outbound single-copy path (stream buffer / encode-in-place) | Comm | Medium (packet copied ~3× today: memcpy → COBS → queue copy) | Med | L | Proposed | `src/app_comm.c`, `src/app_tasks.c` |
+| 14 | Per-address dirty tracking in TM1639/TM1637 (partial flush) | Displays | Medium (single-digit change rewrites whole buffer today) | Med | M | Proposed | `src/tm1639.c`, `src/tm1637.c` |
+| 15 | Interrupt-driven keypad/encoder capture | Inputs | Medium (frees ~500 Hz polling loop) | High (HW rework of mux scan) | L | Proposed | `src/app_inputs.c` |
+| 16 | Link-time optimization (LTO) for `pico-release` | Build | Low–Med (cross-module inlining) | Med (pico-sdk `--wrap` aliasing history; must be CI-validated) | S | Proposed | `CMakePresets.json` / `src/CMakeLists.txt` |
+| 17 | `configUSE_TIMERS=0` (no app software timers exist) | Memory | Low (frees prio-9 daemon + 8 KB stack) | Low (needs link check) | S | Proposed | `include/FreeRTOSConfig.h` |
+| 18 | Tick rate 2000 → 1000 Hz, or tickless idle | Scheduler | Medium (halves tick ISR load) | Med (changes all `pdMS_TO_TICKS` granularity assumptions, 0.5 ms debounce windows) | M | Proposed | `include/FreeRTOSConfig.h` |
+| 19 | `__not_in_flash_func` / copy-to-RAM for hot paths (COBS, framer, ISRs) | CPU | Low–Med (removes XIP cache-miss jitter) | Med | M | Proposed | `src/cobs.c`, `src/encoded_framer.c` |
+| 20 | Remove `select_interface`'s unconditional `sleep_us(1)` (also on deselect) | Displays | Low | Med (HW timing) | S | Proposed | `src/app_outputs.c` |
+| 21 | TM1637: hoist `gpio_set_function`/`gpio_set_dir` out of per-bit pin toggles | Displays | Low–Med | Med (needs HW validation of open-drain emulation) | M | Proposed | `src/tm1637.c` |
+| 22 | Statistics counters: per-core or atomic increments | Correctness (SMP data race, not perf) | — | Low | M | Proposed | `src/error_management.c` |
+| 23 | `-fstack-protector-strong` trade-off review | CPU | Low (per-function canary cost) | Med (safety feature; keep unless profiling says otherwise) | S | Proposed | `src/CMakeLists.txt` |
+| 24 | Batched input events (N events per packet) | Comm | Low–Med (fewer per-event packets under burst) | Med (protocol change) | L | Proposed | protocol + `src/app_comm.c` |
+
+## Implemented items — details & revert guide
+
+Each change keeps a single revert knob and documents it at the definition site.
+
+| Define / site | New value | Old value |
+|---|---|---|
+| `SPI_FREQUENCY` (`include/app_outputs.h`) | `1000U * 1000U` | `500U * 1000U` |
+| `ADC_DEFAULT_SETTLING_US` (`include/app_inputs.h`) | `100U` | `500U` |
+| `CDC_TRANSMIT_QUEUE_SIZE` (`include/app_config.h`) | `256U` | `2048U` |
+| `INPUT_QUEUE_SEND_TIMEOUT_MS` (`include/app_config.h`) | `100U` | `1000U` |
+| `TM1637_DELAY_US` (`src/tm1637.c`) | `2` (build-overridable) | `3` |
+| `configGENERATE_RUN_TIME_STATS` etc. (`include/FreeRTOSConfig.h`) | `0` | `1` |
+| `configUSE_TICK_HOOK` (`include/FreeRTOSConfig.h`) | `0` | `1` |
+
+Notes per item:
+
+1. **ADC settling (item 1).** The wait is a `busy_wait_us_32()` spin on Core 1,
+   paid per enabled channel per scan (16 channels by default). The 74HC4067
+   switches in < 1 µs and the realistic source RC constant (pot wiper + mux
+   R\_on into the S/H and trace capacitance) is well under 10 µs, so 100 µs
+   retains > 10× margin. Also runtime-tunable via `input_config.adc_settling_us`.
+   Raise it back toward 500 µs if adjacent-channel crosstalk appears with
+   high-impedance sources. Unit test pins the ≤ 100 µs contract.
+2. **CDC TX queue (item 2).** The queue stores 27-byte packets by value; 2048
+   slots consumed ~55 KB (43%) of the FreeRTOS heap while only ever feeding a
+   4 KB TinyUSB FIFO. 256 slots (~7 KB) still buffer ~1.7× the FIFO; when the
+   host stalls long enough to fill them, `app_comm_send_packet` already
+   drops-and-counts (`CDC_QUEUE_SEND_ERROR`). Unit test pins a ≤ 16 KB budget.
+3. **TM1639 batch flush (item 3).** The address command and 16 display bytes
+   now go out as one `spi_write_blocking` burst inside the same STB window —
+   identical byte stream, 17× fewer SPI calls. Unit-tested via a capturing SPI
+   mock (`test_flush_batches_address_and_data_in_one_spi_write`).
+4. **SPI 1 MHz (item 4).** TM1639 datasheet maximum is 1 MHz (min CLK pulse
+   400 ns; RP2040 produces 500 ns half-periods at 1 MHz).
+5. **TM1637 delay (item 5).** 2 µs half-period = 250 kHz, a 2× margin under the
+   500 kHz datasheet max. Override with `-DTM1637_DELAY_US=3` if long/loaded
+   wiring needs the slower clock.
+6. **CDC write loop (item 6).** Previously the drain loop executed
+   `taskYIELD()` on every iteration (even after successful writes) and flushed
+   after every 27-byte packet. Now it yields only when the FIFO is actually
+   full, drains every queued packet before one flush (latency unchanged — the
+   flush still happens as soon as the queue empties), and abandons the packet
+   if the host drops the link mid-write instead of spinning until the watchdog
+   fires.
+7-9. **Scheduler trims (items 7–9).** Run-time stats added a timer read to
+   every context switch with no consumer; the tick hook was an empty call at
+   2000 Hz per core; the watermark refresh full-stack scan ran every loop pass
+   in every task (~2.5 MB/s from the keypad task alone) and is now sampled
+   every 64th pass. To profile task CPU usage, temporarily re-enable
+   `configGENERATE_RUN_TIME_STATS` with `portGET_RUN_TIME_COUNTER_VALUE()`
+   mapped to `time_us_32()`.
+10. **Input enqueue timeout (item 10).** A full data-event queue already ended
+   in drop-and-count after blocking the scan for 1 s; the shorter bound only
+   limits the input outage while the 500-slot queue provides the real burst
+   absorption.
+11. **`PICO_HEAP_SZIE` (item 11).** The misspelled define never had any effect.
+   It was removed rather than "fixed": a real `PICO_HEAP_SIZE=0x20000` would
+   demand a 128 KB minimum C heap alongside the 128 KB FreeRTOS heap in
+   264 KB RAM. The C heap is nearly unused (two one-time `pvPortMalloc`
+   driver allocations), so no replacement is needed.
+
+## Proposed items — why deferred
+
+- **Timer/DMA ADC (12):** biggest remaining win on Core 1, but needs a redesign
+  of the scan loop (alarm-driven mux stepping or free-running ADC + DMA ring)
+  and hardware validation of settling behavior.
+- **Single-copy TX path (13):** each outbound packet is currently copied ~3×
+  (payload memcpy → COBS encode → queue copy-by-value). A FreeRTOS stream
+  buffer of encoded bytes, or encoding directly into the TinyUSB FIFO in
+  `cdc_write_task`, would remove two copies — an architectural change to the
+  queue contract, so it needs its own test round.
+- **Dirty tracking (14):** both display drivers rewrite their full buffer on
+  any change. Per-address dirty flags plus fixed-address writes
+  (`TM1639_CMD_FIXED_ADDR`) would shrink single-digit updates ~8×.
+- **LTO (16):** flagged S-effort but must be validated in CI (no local ARM
+  toolchain; pico-sdk has history of `--wrap`/alias breakage under `-flto`).
+- **Tick rate (18):** halving to 1000 Hz halves tick overhead but coarsens
+  every `pdMS_TO_TICKS(1)` sleep to 1 ms and widens debounce windows —
+  needs a timing review of keypad/ADC cadences first.
+- **Statistics atomicity (22):** `counters[index]++` from both cores is a
+  benign-looking SMP data race (lost increments). Fix is per-core counter
+  banks summed on read, or `hardware/sync` spinlocks — correctness work,
+  tracked here so it isn't mistaken for a perf lever.
+
+## Follow-up measurement plan
+
+Before investing in items 12–14, profile on hardware:
+
+1. Re-enable `configGENERATE_RUN_TIME_STATS` on a debug build (map the counter
+   to `time_us_32()`), dump per-task CPU via a debug command, and confirm the
+   ADC/keypad/idle split on Core 1.
+2. Toggle a spare GPIO around the ADC scan and display flush paths and measure
+   with a logic analyzer to validate the computed timings in this document.
+3. Use the existing statistics counters (`INPUT_QUEUE_FULL_ERROR`,
+   `CDC_QUEUE_SEND_ERROR`, `INPUT_HYSTERESIS_SUPPRESSED`) to watch for drops
+   under sustained host load after the queue resizing.
+
+---
+
+**See also:** [Docs index](README.md) · [ARCHITECTURE](ARCHITECTURE.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ project overview, see [`../README.md`](../README.md).
 
 ## Architecture & Protocol
 - [ARCHITECTURE.md](ARCHITECTURE.md) — FreeRTOS SMP task layout, queues, data flows, error management.
+- [PERFORMANCE.md](PERFORMANCE.md) — prioritized performance analysis: implemented quick wins, proposed optimizations, revert guide.
 - [COMMANDS.md](COMMANDS.md) — USB CDC command protocol: COBS framing, command IDs, payload formats, example frames.
 - [OUTPUT.md](OUTPUT.md) — output/display subsystem: SPI fabric, TM1639/TM1637 drivers, buffering, concurrency.
 

--- a/include/FreeRTOSConfig.h
+++ b/include/FreeRTOSConfig.h
@@ -47,7 +47,7 @@
 #define configUSE_PREEMPTION                    1
 #define configUSE_TICKLESS_IDLE                 0
 #define configUSE_IDLE_HOOK                     1
-#define configUSE_TICK_HOOK                     1
+#define configUSE_TICK_HOOK                     0
 #define configTICK_RATE_HZ                      ( ( TickType_t ) 2000 )
 #define configMAX_PRIORITIES                    10
 #define configMINIMAL_STACK_SIZE                ( configSTACK_DEPTH_TYPE ) 256
@@ -84,14 +84,13 @@
 #define configUSE_DAEMON_TASK_STARTUP_HOOK      0
 
 // Run time and task stats gathering related definitions.
-#define configGENERATE_RUN_TIME_STATS           1
-#define configUSE_TRACE_FACILITY                1
-#define configUSE_STATS_FORMATTING_FUNCTIONS    1
-
-// Runtime stats configurations
-extern uint32_t ulPortGetRunTime( void );
-#define portCONFIGURE_TIMER_FOR_RUN_TIME_STATS()
-#define portGET_RUN_TIME_COUNTER_VALUE()            ulPortGetRunTime()
+// Disabled: nothing consumes vTaskGetRunTimeStats/uxTaskGetSystemState, and
+// run-time stats add a timer read to every context switch. Re-enable
+// temporarily (with a portGET_RUN_TIME_COUNTER_VALUE() mapped to
+// time_us_32()) when profiling task CPU usage.
+#define configGENERATE_RUN_TIME_STATS           0
+#define configUSE_TRACE_FACILITY                0
+#define configUSE_STATS_FORMATTING_FUNCTIONS    0
 
 // Co-routine related definitions.
 #define configUSE_CO_ROUTINES                   0
@@ -124,10 +123,6 @@ extern uint32_t ulPortGetRunTime( void );
 
 // PERFORMANCE TUNING for larger stacks
 #define configUSE_TASK_NOTIFICATIONS            1
-#define configUSE_MUTEXES                       1
-#define configUSE_RECURSIVE_MUTEXES             1
-#define configUSE_COUNTING_SEMAPHORES           1
-#define configCHECK_FOR_STACK_OVERFLOW          2    // Critical with large stacks
 
 // Define to trap errors during development.
 #define configASSERT(x)                         assert(x)

--- a/include/FreeRTOSConfig.h
+++ b/include/FreeRTOSConfig.h
@@ -84,13 +84,18 @@
 #define configUSE_DAEMON_TASK_STARTUP_HOOK      0
 
 // Run time and task stats gathering related definitions.
-// Disabled: nothing consumes vTaskGetRunTimeStats/uxTaskGetSystemState, and
-// run-time stats add a timer read to every context switch. Re-enable
-// temporarily (with a portGET_RUN_TIME_COUNTER_VALUE() mapped to
-// time_us_32()) when profiling task CPU usage.
-#define configGENERATE_RUN_TIME_STATS           0
-#define configUSE_TRACE_FACILITY                0
-#define configUSE_STATS_FORMATTING_FUNCTIONS    0
+// Required: the PC_TASK_STATUS_CMD handler (send_heap_status in app_comm.c)
+// reports per-task and idle CPU usage to the host via
+// ulTaskGetRunTimeCounter/Percent and ulTaskGetIdleRunTimeCounter/Percent,
+// all of which need configGENERATE_RUN_TIME_STATS=1.
+#define configGENERATE_RUN_TIME_STATS           1
+#define configUSE_TRACE_FACILITY                1
+#define configUSE_STATS_FORMATTING_FUNCTIONS    1
+
+// Runtime stats configurations
+extern uint32_t ulPortGetRunTime( void );
+#define portCONFIGURE_TIMER_FOR_RUN_TIME_STATS()
+#define portGET_RUN_TIME_COUNTER_VALUE()            ulPortGetRunTime()
 
 // Co-routine related definitions.
 #define configUSE_CO_ROUTINES                   0

--- a/include/app_config.h
+++ b/include/app_config.h
@@ -22,8 +22,15 @@
 
 /**
  * @brief Size of the CDC transmit queue.
+ *
+ * Each slot stores a full @ref cdc_packet_t by value (~27 bytes), so the
+ * queue footprint comes straight out of the FreeRTOS heap: 256 slots ~= 7 KB.
+ * That still buffers ~1.7x the 4 KB TinyUSB TX FIFO; when the host stalls
+ * long enough to fill it, @ref app_comm_send_packet already drops the packet
+ * and counts @c CDC_QUEUE_SEND_ERROR. (Was 2048 slots ~= 55 KB, 43% of the
+ * 128 KB heap, with no additional benefit.)
  */
-#define CDC_TRANSMIT_QUEUE_SIZE 2048U
+#define CDC_TRANSMIT_QUEUE_SIZE 256U
 
 /**
  * @brief Data buffer size (used for inbound/outbound data).
@@ -79,8 +86,14 @@
 
 /**
  * @brief Timeout for sending events to data queues (milliseconds).
+ *
+ * Bounds how long the keypad/encoder scan can stall when the data event
+ * queue is full (host not draining). The enqueue already ends in a
+ * drop-and-count on timeout, so a shorter bound only limits the input-scan
+ * outage; 100 ms still rides out transient host stalls (the 500-slot queue
+ * flushes over full-speed CDC in tens of ms once the host resumes).
  */
-#define INPUT_QUEUE_SEND_TIMEOUT_MS 1000U
+#define INPUT_QUEUE_SEND_TIMEOUT_MS 100U
 
 /**
  * @brief Retry delay for queue polling in task loops (milliseconds).

--- a/include/app_inputs.h
+++ b/include/app_inputs.h
@@ -93,8 +93,18 @@
 #define ADC_NUM_TAPS 4U
 /** log2(@ref ADC_NUM_TAPS); used for mask/shift optimisations in the filter. */
 #define ADC_NUM_TAPS_SHIFT 2U
-/** Default µs settling delay between channel selections (74HC4067 + ~10 kΩ pot). */
-#define ADC_DEFAULT_SETTLING_US 500U
+/**
+ * Default µs settling delay between channel selections (74HC4067 + ~10 kΩ pot).
+ *
+ * This delay is a busy_wait_us_32() spin on core 1, paid once per enabled
+ * channel per scan, so it dominates the ADC task's CPU cost (16 channels x
+ * this value per scan). The 74HC4067 switches in < 1 µs and the realistic
+ * source RC constant is well under 10 µs, so 100 µs keeps > 10x margin while
+ * cutting the per-scan spin from ~8 ms to ~1.6 ms. Runtime-tunable through
+ * input_config.adc_settling_us; raise back toward 500U if a high-impedance
+ * source shows crosstalk between adjacent channels.
+ */
+#define ADC_DEFAULT_SETTLING_US 100U
 /** Default number of raw samples averaged per channel per scan. */
 #define ADC_DEFAULT_OVERSAMPLE 4U
 /** Default hysteresis (in raw 12-bit LSBs) applied before emitting a new event. */

--- a/include/app_outputs.h
+++ b/include/app_outputs.h
@@ -28,8 +28,14 @@
  * @name SPI fabric configuration
  * @{
  */
-/** Nominal SPI bus frequency used for TM1639 devices (500 kHz). */
-#define SPI_FREQUENCY (500U * 1000U)
+/**
+ * Nominal SPI bus frequency used for TM1639 devices (1 MHz).
+ *
+ * 1 MHz is the TM1639 datasheet maximum (min CLK pulse width 400 ns; the
+ * RP2040 SPI produces 500 ns half-periods at this rate). Revert to
+ * (500U * 1000U) if signal integrity through the multiplexer degrades.
+ */
+#define SPI_FREQUENCY (1000U * 1000U)
 /** Total number of logical SPI interfaces exposed through the multiplexer. */
 #define MAX_SPI_INTERFACES 8U
 /** Number of GPIOs exposed by the RP2040 package. */

--- a/include/hooks.h
+++ b/include/hooks.h
@@ -29,9 +29,4 @@ void vApplicationIdleHook(void);
  */
 void vApplicationStackOverflowHook(TaskHandle_t pxTask, char *pcTaskName);
 
-/**
- * @brief Periodic callback executed from the system tick interrupt.
- */
-void vApplicationTickHook(void);
-
 #endif // HOOKS_H

--- a/include/tusb_config.h
+++ b/include/tusb_config.h
@@ -53,8 +53,13 @@ extern "C" {
 #define CFG_TUSB_MCU          OPT_MCU_RP2040
 #endif
 
+// The real value is injected on the compiler command line by the build:
+// the top-level CMakeLists.txt sets TINYUSB_OPT_OS to OPT_OS_FREERTOS before
+// the Pico SDK loads TinyUSB, which makes tud_task_ext() block on the TinyUSB
+// event queue instead of polling. This fallback only exists so IDEs/linters
+// that parse the header without the build flags resolve to the same OSAL.
 #ifndef CFG_TUSB_OS
-#define CFG_TUSB_OS           OPT_OS_NONE
+#define CFG_TUSB_OS           OPT_OS_FREERTOS
 #endif
 
 #ifndef CFG_TUSB_DEBUG

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -90,7 +90,6 @@ target_compile_definitions(pi_controller PRIVATE
     PICO_USE_FASTEST_SUPPORTED_CLOCK=1
     PICO_STACK_SIZE=0x1000 # 4KB main stack
     PICO_CORE1_STACK_SIZE=0x1000 # 4KB Core 1 stack
-    PICO_HEAP_SZIE=0x20000
     PICO_USE_STACK_GUARDS=1
     PICO_STACK_GUARDS=1
 )

--- a/src/app_inputs.c
+++ b/src/app_inputs.c
@@ -374,6 +374,7 @@ void keypad_task(void *pvParameters)
 {
 	task_props_t * task_props = (task_props_t*) pvParameters;
 	encoder_states_t encoder_state[MAX_NUM_ENCODERS];
+	uint32_t loop_count = 0U;
 
 	for (uint8_t i = 0U; i < MAX_NUM_ENCODERS; i++)
 	{
@@ -428,7 +429,14 @@ void keypad_task(void *pvParameters)
 			scan_encoders(encoder_state);
 		}
 
-		task_props->high_watermark = uxTaskGetStackHighWaterMark(NULL);
+		/* The watermark scan walks the whole task stack; at a ~2 ms scan
+		 * cadence that is ~2.5 MB/s of reads, so refresh it only every
+		 * 64th pass (diagnostic-only data). */
+		if (0U == (loop_count & 63U))
+		{
+			task_props->high_watermark = uxTaskGetStackHighWaterMark(NULL);
+		}
+		loop_count++;
 		watchdog_update();
 
 		// Scan-cycle interval: controls debounce window (window = key_settling_time_ms * required samples)
@@ -549,6 +557,7 @@ void adc_read_task(void *pvParameters)
 	static bool adc_channel_primed[ADC_CHANNELS];
 
 	task_props_t * task_props = (task_props_t*) pvParameters;
+	uint32_t loop_count = 0U;
 
 	// Initialize the ADC states
 	for (uint8_t i = 0; i < ADC_CHANNELS; i++)
@@ -617,7 +626,13 @@ void adc_read_task(void *pvParameters)
 		// idle ADC line while same-priority tasks run.
 		adc_mux_select(0);
 
-		task_props->high_watermark = uxTaskGetStackHighWaterMark(NULL);
+		/* Diagnostic-only full-stack scan: refresh every 64th pass to keep
+		 * it off the scan hot path. */
+		if (0U == (loop_count & 63U))
+		{
+			task_props->high_watermark = uxTaskGetStackHighWaterMark(NULL);
+		}
+		loop_count++;
 		watchdog_update();
 
 		// Cooperative yield: lets same-priority tasks (keypad) run between scans

--- a/src/app_tasks.c
+++ b/src/app_tasks.c
@@ -634,3 +634,16 @@ static void led_status_task(void *pvParameters)
 		task_prop->high_watermark = uxTaskGetStackHighWaterMark(NULL);
 	}
 }
+
+/**
+ * @brief FreeRTOS hook that retrieves the current runtime counter in microseconds.
+ *
+ * Backs portGET_RUN_TIME_COUNTER_VALUE() so the kernel can accumulate per-task
+ * run time for the PC_TASK_STATUS_CMD reporting path (see app_comm.c).
+ *
+ * @return Monotonic runtime value used by the kernel statistics module.
+ */
+uint32_t ulPortGetRunTime(void)
+{
+	return time_us_32();
+}

--- a/src/app_tasks.c
+++ b/src/app_tasks.c
@@ -322,12 +322,19 @@ static void uart_event_task(void *pvParameters)
 	uint8_t receive_buffer[CDC_READ_CHUNK_SIZE];
 	encoded_framer_t framer;
 	encoded_frame_t frame;
+	uint32_t loop_count = 0U;
 
 	encoded_framer_reset(&framer);
 
 	for (;;)
 	{
-		task_prop->high_watermark = uxTaskGetStackHighWaterMark(NULL);
+		/* Full-stack watermark scans are diagnostic-only; refresh every
+		 * 64th pass to keep them off the RX hot path. */
+		if (0U == (loop_count & 63U))
+		{
+			task_prop->high_watermark = uxTaskGetStackHighWaterMark(NULL);
+		}
+		loop_count++;
 		watchdog_update();
 
 		QueueHandle_t queue = app_context_get_encoded_queue();
@@ -403,10 +410,15 @@ static void uart_event_task(void *pvParameters)
 static void cdc_task(void *pvParameters)
 {
 	task_props_t *task_prop = (task_props_t *)pvParameters;
+	uint32_t loop_count = 0U;
 	for (;;)
 	{
 		tud_task_ext(CDC_TASK_SAFETY_TIMEOUT_MS, false);
-		task_prop->high_watermark = uxTaskGetStackHighWaterMark(NULL);
+		if (0U == (loop_count & 63U))
+		{
+			task_prop->high_watermark = uxTaskGetStackHighWaterMark(NULL);
+		}
+		loop_count++;
 		watchdog_update();
 	}
 }
@@ -421,10 +433,15 @@ static void decode_reception_task(void *pvParameters)
 	task_props_t *task_prop = (task_props_t *)pvParameters;
 	encoded_frame_t frame;
 	uint8_t decode_buffer[MAX_ENCODED_BUFFER_SIZE];
+	uint32_t loop_count = 0U;
 
 	for (;;)
 	{
-		task_prop->high_watermark = uxTaskGetStackHighWaterMark(NULL);
+		if (0U == (loop_count & 63U))
+		{
+			task_prop->high_watermark = uxTaskGetStackHighWaterMark(NULL);
+		}
+		loop_count++;
 		watchdog_update();
 
 		// Get queue handle and wait if not created yet
@@ -468,10 +485,15 @@ static void decode_reception_task(void *pvParameters)
 static void process_outbound_task(void *pvParameters)
 {
 	task_props_t *task_prop = (task_props_t *)pvParameters;
+	uint32_t loop_count = 0U;
 
 	for (;;)
 	{
-		task_prop->high_watermark = uxTaskGetStackHighWaterMark(NULL);
+		if (0U == (loop_count & 63U))
+		{
+			task_prop->high_watermark = uxTaskGetStackHighWaterMark(NULL);
+		}
+		loop_count++;
 		watchdog_update();
 
 		QueueHandle_t data_queue = app_context_get_data_event_queue();
@@ -500,6 +522,7 @@ static void cdc_write_task(void *pvParameters)
 {
 	task_props_t *task_prop = (task_props_t *)pvParameters;
 	cdc_packet_t packet;
+	uint32_t loop_count = 0U;
 
 	for (;;)
 	{
@@ -511,28 +534,55 @@ static void cdc_write_task(void *pvParameters)
 				vTaskDelay(pdMS_TO_TICKS(QUEUE_RETRY_DELAY_MS));
 			}
 
-			size_t total_written = 0U;
-			while (total_written < packet.length)
+			/* Drain every queued packet into the TinyUSB TX FIFO before a
+			 * single flush: coalescing small packets into fewer USB
+			 * transfers raises throughput without adding latency (the
+			 * flush still happens as soon as the queue runs empty). */
+			bool more_packets = true;
+			while (more_packets)
 			{
-				const uint32_t available = tud_cdc_n_write_available(0);
-				const uint32_t remaining = (uint32_t)packet.length - (uint32_t)total_written;
-				const uint32_t to_write = (available < remaining) ? available : remaining;
-
-				if (to_write > 0U)
+				size_t total_written = 0U;
+				while (total_written < packet.length)
 				{
-					uint32_t written = tud_cdc_n_write(0, &packet.data[total_written], to_write);
-					total_written += written;
+					const uint32_t available = tud_cdc_n_write_available(0);
+					const uint32_t remaining = (uint32_t)packet.length - (uint32_t)total_written;
+					const uint32_t to_write = (available < remaining) ? available : remaining;
+
+					if (to_write > 0U)
+					{
+						uint32_t written = tud_cdc_n_write(0, &packet.data[total_written], to_write);
+						total_written += written;
+					}
+					else if (!app_context_is_cdc_ready())
+					{
+						/* Host dropped the link mid-packet: abandon the
+						 * remainder instead of spinning into the watchdog. */
+						break;
+					}
+					else
+					{
+						/* FIFO full: yield until cdc_task drains it.
+						 * tud_task() is serviced exclusively by cdc_task to
+						 * avoid reentering the TinyUSB device stack from two
+						 * tasks. */
+						taskYIELD();
+					}
 				}
 
-				/* tud_task() is serviced exclusively by cdc_task to avoid
-				 * reentering the TinyUSB device stack from two tasks. */
-				taskYIELD();
+				statistics_add_to_counter(BYTES_SENT, (uint32_t)total_written);
+				more_packets = (pdTRUE == xQueueReceive(queue, &packet, 0U));
 			}
 
 			(void)tud_cdc_write_flush();
-			statistics_add_to_counter(BYTES_SENT, (uint32_t)total_written);
 		}
-		task_prop->high_watermark = uxTaskGetStackHighWaterMark(NULL);
+
+		/* The watermark scan walks the whole task stack; refresh it only
+		 * every 64th pass to keep it out of the steady-state hot path. */
+		if (0U == (loop_count & 63U))
+		{
+			task_prop->high_watermark = uxTaskGetStackHighWaterMark(NULL);
+		}
+		loop_count++;
 		watchdog_update();
 	}
 }
@@ -583,14 +633,4 @@ static void led_status_task(void *pvParameters)
 		watchdog_update();
 		task_prop->high_watermark = uxTaskGetStackHighWaterMark(NULL);
 	}
-}
-
-/**
- * @brief FreeRTOS hook that retrieves the current runtime counter in microseconds.
- *
- * @return Monotonic runtime value used by the kernel statistics module.
- */
-uint32_t ulPortGetRunTime(void)
-{
-	return time_us_32();
 }

--- a/src/hooks.c
+++ b/src/hooks.c
@@ -45,8 +45,3 @@ void vApplicationIdleHook(void)
 	free_heap_size = xPortGetFreeHeapSize();
 }
 //-----------------------------------------------------------
-
-void vApplicationTickHook(void)
-{
-	// Tick hook
-}

--- a/src/tm1637.c
+++ b/src/tm1637.c
@@ -52,7 +52,13 @@ static output_result_t tm1637_set_brightness_output(output_driver_t *config, uin
 
 // ---- Bit-bang helpers (open-drain emulation) ----
 
-#define TM1637_DELAY_US (3)
+/* Half-period of the bit-banged clock. 2 µs -> 250 kHz, a 2x margin under
+ * the TM1637 datasheet maximum of 500 kHz. Every byte costs ~16 delays while
+ * the caller holds the SPI mutex, so this value directly bounds display
+ * latency. Build-overridable; raise back to 3 if long/loaded wiring needs it. */
+#ifndef TM1637_DELAY_US
+#define TM1637_DELAY_US (2)
+#endif
 
 /**
  * @brief Configure a TM1637 signal for open-drain high state.

--- a/src/tm1639.c
+++ b/src/tm1639.c
@@ -257,28 +257,23 @@ static tm1639_result_t tm1639_flush(output_driver_t *config)
 
 		tm1639_stop(config); // STB goes high - Required between commands
 
-		// Step 2: Send address command and write all buffer data
+		// Step 2: Send address command and all buffer data as one SPI burst.
+		// Batching the 17 bytes into a single spi_write_blocking() call keeps
+		// the transaction on the wire back-to-back instead of paying the
+		// per-call setup cost 17 times while the SPI mutex is held.
 		if (TM1639_OK == result)
 		{
-			tm1639_start(config); // STB goes low again
+			uint8_t tx_buffer[1U + TM1639_DISPLAY_BUFFER_SIZE];
 
 			// Set starting address to 0x00: 11000000 (0xC0)
-			if (tm1639_write_byte(config, TM1639_CMD_ADDR_BASE) != 1)
+			tx_buffer[0] = TM1639_CMD_ADDR_BASE;
+			(void)memcpy(&tx_buffer[1], config->active_buffer, TM1639_DISPLAY_BUFFER_SIZE);
+
+			tm1639_start(config); // STB goes low again
+
+			if (spi_write_blocking(config->spi, tx_buffer, sizeof(tx_buffer)) != (int)sizeof(tx_buffer))
 			{
 				result = TM1639_ERR_SPI_WRITE;
-			}
-			else
-			{
-				// Write all 16 bytes from active buffer
-				// MISRA-C: Declare loop variable with reduced scope
-				for (uint8_t i = 0U; (i < TM1639_DISPLAY_BUFFER_SIZE) && (TM1639_OK == result); i++)
-				{
-					if (tm1639_write_byte(config, config->active_buffer[i]) != 1)
-					{
-						result = TM1639_ERR_SPI_WRITE;
-						// Break handled by loop condition
-					}
-				}
 			}
 
 			tm1639_stop(config); // STB goes high to end transaction

--- a/test/unit/hardware_mocks.c
+++ b/test/unit/hardware_mocks.c
@@ -7,6 +7,7 @@
 #include <stdbool.h>
 #include <stdarg.h>
 #include <stddef.h>
+#include <string.h>
 #include "hardware/pwm.h"
 
 // Pico SDK mock types and functions
@@ -96,7 +97,52 @@ void spi_set_format(spi_inst_t *spi, uint32_t data_bits, uint32_t cpol, uint32_t
     (void)spi; (void)data_bits; (void)cpol; (void)cpha; (void)order;
 }
 void gpio_set_function(uint32_t gpio, uint32_t fn) { (void)gpio; (void)fn; }
-int spi_write_blocking(spi_inst_t *spi, const uint8_t *src, size_t len) { (void)spi; (void)src; return (int)len; }
+/* Keep these capture definitions layout-identical to the test-only section
+ * of mock_headers/hardware/spi.h (this file deliberately does not include
+ * that header because its SPI prototypes differ from the mocks below). */
+#define MOCK_SPI_MAX_CALLS     32U
+#define MOCK_SPI_CAPTURE_BYTES 24U
+
+typedef struct {
+    size_t len;
+    uint8_t data[MOCK_SPI_CAPTURE_BYTES];
+} mock_spi_call_t;
+
+static mock_spi_call_t mock_spi_calls[MOCK_SPI_MAX_CALLS];
+static size_t mock_spi_num_calls = 0U;
+
+void mock_spi_reset(void)
+{
+    mock_spi_num_calls = 0U;
+    memset(mock_spi_calls, 0, sizeof(mock_spi_calls));
+}
+
+size_t mock_spi_call_count(void)
+{
+    return mock_spi_num_calls;
+}
+
+const mock_spi_call_t *mock_spi_call(size_t index)
+{
+    return (index < mock_spi_num_calls) ? &mock_spi_calls[index] : NULL;
+}
+
+int spi_write_blocking(spi_inst_t *spi, const uint8_t *src, size_t len)
+{
+    (void)spi;
+    if (mock_spi_num_calls < MOCK_SPI_MAX_CALLS)
+    {
+        mock_spi_call_t *call = &mock_spi_calls[mock_spi_num_calls];
+        call->len = len;
+        size_t capture = (len < MOCK_SPI_CAPTURE_BYTES) ? len : (size_t)MOCK_SPI_CAPTURE_BYTES;
+        if (src != NULL)
+        {
+            memcpy(call->data, src, capture);
+        }
+        mock_spi_num_calls++;
+    }
+    return (int)len;
+}
 
 // FreeRTOS real implementation now used - no more mocks needed
 size_t xPortGetMinimumEverFreeHeapSize(void)

--- a/test/unit/mock_headers/hardware/spi.h
+++ b/test/unit/mock_headers/hardware/spi.h
@@ -9,3 +9,18 @@ extern spi_inst_t *spi0;
 void spi_init(spi_inst_t *spi, unsigned int baudrate);
 void spi_set_format(spi_inst_t *spi, unsigned int data_bits, unsigned int cpol, unsigned int cpha, bool lsb_first);
 int spi_write_blocking(spi_inst_t *spi, const uint8_t *src, size_t len);
+
+/* Test-only capture helpers (implemented in hardware_mocks.c): every
+ * spi_write_blocking call is recorded so tests can assert on transaction
+ * batching, not just buffer contents. */
+#define MOCK_SPI_MAX_CALLS     32U
+#define MOCK_SPI_CAPTURE_BYTES 24U
+
+typedef struct {
+    size_t len;
+    uint8_t data[MOCK_SPI_CAPTURE_BYTES];
+} mock_spi_call_t;
+
+void mock_spi_reset(void);
+size_t mock_spi_call_count(void);
+const mock_spi_call_t *mock_spi_call(size_t index);

--- a/test/unit/test_app_comm.c
+++ b/test/unit/test_app_comm.c
@@ -14,6 +14,7 @@
 #include "queue.h"
 
 #include "app_comm.h"
+#include "app_config.h"
 #include "app_context.h"
 #include "commands.h"
 #include "error_management.h"
@@ -83,11 +84,24 @@ static void test_send_packet_rejects_oversized_payload(void **state)
 	assert_int_equal(statistics_get_counter(BUFFER_OVERFLOW_ERROR), 1);
 }
 
+static void test_cdc_queue_memory_budget(void **state)
+{
+	(void)state;
+
+	/* The CDC transmit queue is copy-by-value (one cdc_packet_t per slot),
+	 * so its footprint comes straight out of the FreeRTOS heap. Keep the
+	 * budget at or below 16 KB (12.5% of the 128 KB heap) while retaining
+	 * enough depth to buffer well beyond the 4 KB TinyUSB TX FIFO. */
+	assert_true((CDC_TRANSMIT_QUEUE_SIZE * sizeof(cdc_packet_t)) <= (16U * 1024U));
+	assert_true(CDC_TRANSMIT_QUEUE_SIZE >= 128U);
+}
+
 int main(void)
 {
 	const struct CMUnitTest tests[] = {
 		cmocka_unit_test_setup(test_send_packet_accepts_max_payload, setup_test),
 		cmocka_unit_test_setup(test_send_packet_rejects_oversized_payload, setup_test),
+		cmocka_unit_test_setup(test_cdc_queue_memory_budget, setup_test),
 	};
 
 	return cmocka_run_group_tests(tests, NULL, NULL);

--- a/test/unit/test_inputs.c
+++ b/test/unit/test_inputs.c
@@ -317,7 +317,11 @@ static void test_adc_default_settling_is_microsecond_scale(void **state)
     /* The header default is the contract: tests bind here so an accidental
      * regression to 0 (or back to a millisecond-scale value) is caught. */
     assert_true(ADC_DEFAULT_SETTLING_US > 0U);
-    assert_true(ADC_DEFAULT_SETTLING_US <= 5000U); /* keep per-channel cycle < ~5 ms */
+    /* The settling wait is a busy_wait_us_32 spin on core 1: with 16 channels
+     * per scan, every 100 µs here costs 1.6 ms of CPU spin per scan cycle.
+     * The 74HC4067 switches in < 1 µs, so 100 µs already carries a large
+     * margin — keep the busy-spin budget per scan at or below ~2 ms. */
+    assert_true(ADC_DEFAULT_SETTLING_US <= 100U);
     assert_true(ADC_DEFAULT_OVERSAMPLE >= 1U);
     assert_true(ADC_DEFAULT_SCAN_INTERVAL_MS >= 1U);
     assert_true(ADC_NUM_TAPS >= 4U); /* must keep at least the legacy filter depth */

--- a/test/unit/test_outputs.c
+++ b/test/unit/test_outputs.c
@@ -350,8 +350,10 @@ static void test_pin_constants(void **state)
 static void test_spi_frequency_constant(void **state)
 {
 	(void) state;
-	// Test SPI frequency is reasonable (500 kHz)
-	assert_int_equal(500000, SPI_FREQUENCY);
+	// 1 MHz is the TM1639 datasheet maximum (min CLK pulse width 400 ns;
+	// 1 MHz gives 500 ns half-periods). Revert to 500 kHz if signal
+	// integrity through the mux becomes an issue.
+	assert_int_equal(1000000, SPI_FREQUENCY);
 }
 
 static void test_max_interfaces_constant(void **state)

--- a/test/unit/test_tm1639.c
+++ b/test/unit/test_tm1639.c
@@ -169,6 +169,40 @@ static void test_set_leds_clears_previously_lit_leds(void **state)
     assert_int_equal(0x05, driver.active_buffer[5]);
 }
 
+static void test_flush_batches_address_and_data_in_one_spi_write(void **state)
+{
+    (void) state;
+    output_driver_t driver;
+    init_stub_driver(&driver);
+
+    mock_spi_reset();
+
+    // set_leds marks the buffer modified and triggers a full flush.
+    assert_int_equal(OUTPUT_OK, tm1639_set_leds(&driver, 0U, 0xFFU));
+
+    // The flush must be exactly two SPI transactions: the data command,
+    // then the address command batched with all 16 buffer bytes.
+    assert_int_equal(2, mock_spi_call_count());
+
+    const mock_spi_call_t *cmd = mock_spi_call(0U);
+    assert_non_null(cmd);
+    assert_int_equal(1, cmd->len);
+    assert_int_equal(TM1639_CMD_DATA_WRITE, cmd->data[0]);
+
+    const mock_spi_call_t *burst = mock_spi_call(1U);
+    assert_non_null(burst);
+    assert_int_equal(1U + TM1639_DISPLAY_BUFFER_SIZE, burst->len);
+    assert_int_equal(TM1639_CMD_ADDR_BASE, burst->data[0]);
+
+    // Column 0 payload lands at addresses 0 and 1 (low/high nibble split);
+    // the rest of the buffer stays dark.
+    assert_int_equal(0x0F, burst->data[1]);
+    assert_int_equal(0x0F, burst->data[2]);
+    for (size_t i = 3U; i <= TM1639_DISPLAY_BUFFER_SIZE; i++) {
+        assert_int_equal(0x00, burst->data[i]);
+    }
+}
+
 static void test_set_leds_example_from_protocol_doc(void **state)
 {
     (void) state;
@@ -201,6 +235,7 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_set_leds_preserves_adjacent_columns, setup, teardown),
         cmocka_unit_test_setup_teardown(test_set_leds_clears_previously_lit_leds, setup, teardown),
         cmocka_unit_test_setup_teardown(test_set_leds_example_from_protocol_doc, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_flush_batches_address_and_data_in_one_spi_write, setup, teardown),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
Replace the 17 one-byte spi_write_blocking() calls in tm1639_flush with a
single 17-byte transfer (0xC0 address command + 16 display bytes) inside
the same STB window, cutting per-call overhead and SPI mutex hold time.
The wire protocol byte stream is unchanged.

Add a capturing spi_write_blocking mock plus a unit test asserting the
flush is exactly two SPI transactions with the expected payload layout.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0117tQvY6FkfFaL4AJZo8kKa